### PR TITLE
[FIX] hotfix for resume analysis

### DIFF
--- a/components/ai-coach/shared/ResumeAndJobInput.tsx
+++ b/components/ai-coach/shared/ResumeAndJobInput.tsx
@@ -65,12 +65,16 @@ export function ResumeAndJobInput({
           name: "Current Resume",
           length: effectiveResumeText.length || 0,
         });
+        // Update parent component's resumeText if it's empty but we have cached data
+        if (!resumeText && cachedData.resumeText && setResumeText) {
+          setResumeText(cachedData.resumeText);
+        }
       } else {
         setUserHasResume(false);
       }
       setIsCheckingResume(false);
     }
-  }, [user?.id, resumeText, cachedData.resumeText, cacheLoading.resume]);
+  }, [user?.id, resumeText, cachedData.resumeText, cacheLoading.resume, setResumeText]);
 
   const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];


### PR DESCRIPTION
The component detected the cached resume data but didn't update the parent component's state. Now when "use current resume" is selected and cached data exists, it will properly set the resume text for analysis.