### PR TITLE
feat: dashboard UX/UI audit fixes

### DIFF
--- a/app/(app)/dashboard/add/page.tsx
+++ b/app/(app)/dashboard/add/page.tsx
@@ -27,6 +27,7 @@ import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import { useSupabaseAuth } from "@/hooks/use-supabase-auth";
 import { useSupabaseApplications } from "@/hooks/use-supabase-applications";
+import { useFeatureFlag, FEATURE_FLAGS } from "@/lib/hooks/use-feature-flag";
 
 import { DateInput } from "@/components/ui/date-input";
 
@@ -44,6 +45,7 @@ export default function AddApplicationPage() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const router = useRouter();
+  const isAuditEnabled = useFeatureFlag(FEATURE_FLAGS.DASHBOARD_UX_AUDIT);
 
   useEffect(() => {
     if (!authLoading && !user) {
@@ -112,7 +114,7 @@ export default function AddApplicationPage() {
               <form onSubmit={handleSubmit} className="space-y-6">
                 {error && (
                   <div className="space-y-3">
-                    <div className="p-3 text-sm text-red-600 bg-red-50 border border-red-200 rounded-md">
+                    <div className={`p-3 text-sm rounded-md ${isAuditEnabled ? "text-destructive bg-destructive/10 border border-destructive/20" : "text-red-600 bg-red-50 border border-red-200"}`}>
                       {error}
                     </div>
                     {error.includes("100 applications") && (

--- a/app/(app)/dashboard/ai-coach/page.tsx
+++ b/app/(app)/dashboard/ai-coach/page.tsx
@@ -18,7 +18,7 @@ export default async function AICoachPage() {
         <div className="max-w-6xl mx-auto space-y-8">
           {/* Header */}
           <div className="space-y-2">
-            <h1 className="text-2xl sm:text-3xl font-bold text-primary flex items-center gap-2 sm:gap-3">
+            <h1 className="text-2xl sm:text-3xl font-bold text-foreground flex items-center gap-2 sm:gap-3">
               AI Career Coach
             </h1>
             <p className="text-muted-foreground">

--- a/app/(app)/dashboard/application/[id]/page.tsx
+++ b/app/(app)/dashboard/application/[id]/page.tsx
@@ -40,6 +40,7 @@ import { archiveApplicationAction, deleteApplicationAction } from "@/lib/actions
 import { Sparkles } from "lucide-react"
 import { LinkedInContactsSection } from "@/components/linkedin-contacts-section"
 import { formatLocalDate, formatLocalDateTime } from "@/lib/utils/date"
+import { useFeatureFlag, FEATURE_FLAGS } from "@/lib/hooks/use-feature-flag"
 
 export default function ApplicationDetailPage() {
   const { user, loading: authLoading } = useSupabaseAuth()
@@ -50,6 +51,7 @@ export default function ApplicationDetailPage() {
   const [saving, setSaving] = useState(false)
   const router = useRouter()
   const params = useParams()
+  const isAuditEnabled = useFeatureFlag(FEATURE_FLAGS.DASHBOARD_UX_AUDIT)
   const [showOfferModal, setShowOfferModal] = useState(false)
   const [offerModalStatus, setOfferModalStatus] = useState<"Offer" | "Hired">("Offer")
   const { isOnFreePlan } = useSubscription(user?.id || null)
@@ -217,7 +219,7 @@ export default function ApplicationDetailPage() {
           {/* Application Overview */}
           <Card>
             <CardHeader>
-              <div className="flex items-start justify-between gap-4">
+              <div className={isAuditEnabled ? "flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4" : "flex items-start justify-between gap-4"}>
                 <div className="space-y-2 flex-1 min-w-0">
                   <CardTitle className="text-xl sm:text-2xl break-words">{application.role}</CardTitle>
                   <CardDescription className="text-base sm:text-lg break-words">{application.company}</CardDescription>
@@ -247,7 +249,7 @@ export default function ApplicationDetailPage() {
                       <AlertDialog>
                         <AlertDialogTrigger asChild>
                           <DropdownMenuItem
-                            className="text-red-600 focus:text-red-600"
+                            className={isAuditEnabled ? "text-destructive focus:text-destructive" : "text-red-600 focus:text-red-600"}
                             onSelect={(e) => e.preventDefault()}
                           >
                             <Trash className="h-4 w-4 mr-2" />
@@ -267,7 +269,7 @@ export default function ApplicationDetailPage() {
                             <AlertDialogAction
                               onClick={handleDeleteApplication}
                               disabled={isDeleting}
-                              className="bg-red-600 hover:bg-red-700"
+                              className={isAuditEnabled ? "bg-destructive hover:bg-destructive/90" : "bg-red-600 hover:bg-red-700"}
                             >
                               {isDeleting ? "Deleting..." : "Delete"}
                             </AlertDialogAction>
@@ -431,7 +433,7 @@ export default function ApplicationDetailPage() {
                                       <AlertDialogCancel>Cancel</AlertDialogCancel>
                                       <AlertDialogAction
                                         onClick={() => handleDeleteNote(index)}
-                                        className="bg-red-600 hover:bg-red-700"
+                                        className={isAuditEnabled ? "bg-destructive hover:bg-destructive/90" : "bg-red-600 hover:bg-red-700"}
                                       >
                                         Delete
                                       </AlertDialogAction>

--- a/app/(app)/dashboard/applications/page.tsx
+++ b/app/(app)/dashboard/applications/page.tsx
@@ -31,7 +31,7 @@ export default async function ApplicationsPage() {
             </Button>
           </Link>
           <div className="flex-1">
-            <h1 className="text-2xl sm:text-3xl font-bold text-primary">
+            <h1 className="text-2xl sm:text-3xl font-bold text-foreground">
               All Applications
             </h1>
             <p className="text-muted-foreground">

--- a/app/(app)/dashboard/archived/page.tsx
+++ b/app/(app)/dashboard/archived/page.tsx
@@ -36,7 +36,7 @@ export default async function ArchivedApplicationsPage() {
             </Button>
           </Link>
           <div className="space-y-2">
-            <h1 className="text-2xl sm:text-3xl font-bold text-primary">
+            <h1 className="text-2xl sm:text-3xl font-bold text-foreground">
               Archived Applications
             </h1>
             <p className="text-muted-foreground">

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -1,6 +1,5 @@
 export const dynamic = "force-dynamic";
 import { redirect } from "next/navigation";
-import { ApplicationPipelineChart } from "@/components/application-pipeline-chart";
 import { NavigationServer } from "@/components/navigation-server";
 import { SubscriptionUsageBannerServer } from "@/components/subscription-usage-banner-server";
 import {
@@ -9,21 +8,15 @@ import {
   getApplications,
   getApplicationHistory,
 } from "@/lib/supabase/server";
-import { AICoachDashboardIntegration } from "@/components/ai-coach-navigation";
-import {
-  NavigationErrorBoundary,
-  AICoachFallback,
-} from "@/components/NavigationErrorBoundary";
 import { getPermissionLevelFromPlan } from "@/lib/constants/navigation";
-import { APPLICATION_LIMITS } from "@/lib/constants/navigation";
 import type { Application, ApplicationHistory } from "@/types";
-import { DashboardApplicationsList } from "@/components/dashboard-applications-list";
 import { DashboardSuccessToast } from "@/components/dashboard-success-toast";
 import { Toaster } from "@/components/ui/toaster";
 import { DashboardWithOnboarding } from "@/components/dashboard-with-onboarding";
-import { DashboardStats } from "@/components/dashboard-stats";
 import { HiredSubscriptionBanner } from "@/components/hired-subscription-banner";
 import { isOnProOrHigher } from "@/lib/utils/plan-helpers";
+import { DashboardLayoutWrapper } from "@/components/dashboard-layout-wrapper";
+import { getServerFeatureFlag } from "@/lib/analytics/posthog-server";
 
 export default async function DashboardPage() {
   // Add a timeout to prevent hanging
@@ -71,6 +64,17 @@ export default async function DashboardPage() {
     const planName = subscription?.subscription_plans?.name;
     const userPlan = getPermissionLevelFromPlan(planName);
 
+    // Evaluate feature flag server-side to avoid flash of content
+    let isAuditEnabled = false;
+    try {
+      isAuditEnabled = await Promise.race([
+        getServerFeatureFlag(user.id, "dashboard-ux-audit-v1"),
+        new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 2000)),
+      ]);
+    } catch {
+      // Flag fetch failed — fall back to disabled
+    }
+
     return (
       <DashboardWithOnboarding>
         <div className="min-h-screen bg-background">
@@ -83,7 +87,7 @@ export default async function DashboardPage() {
           >
             {/* Header Section */}
             <header className="space-y-2">
-              <h1 className="text-2xl sm:text-3xl font-bold text-primary">
+              <h1 className="text-2xl sm:text-3xl font-bold text-foreground">
                 Dashboard
               </h1>
               <p className="text-sm sm:text-base text-muted-foreground">
@@ -103,43 +107,13 @@ export default async function DashboardPage() {
               userId={user.id}
             />
 
-            {/* Stats Cards - Client-side for live data */}
-            <DashboardStats userId={user.id} />
-
-            {/* AI Coach Integration */}
-            <NavigationErrorBoundary fallback={<AICoachFallback />}>
-              <AICoachDashboardIntegration
-                userPlan={userPlan}
-                recentApplications={applications.slice(
-                  0,
-                  APPLICATION_LIMITS.DASHBOARD_DISPLAY
-                )}
-                userId={user.id}
-              />
-            </NavigationErrorBoundary>
-
-            {/* Applications List */}
-            <section aria-labelledby="applications-heading">
-              <h2 id="applications-heading" className="sr-only">
-                Recent Applications
-              </h2>
-              <DashboardApplicationsList
-                userId={user.id}
-                initialApplications={applications}
-                initialTotal={applications.length}
-              />
-            </section>
-
-            {/* Application Pipeline Chart */}
-            <section aria-labelledby="chart-heading">
-              <h2 id="chart-heading" className="sr-only">
-                Application Pipeline Visualization
-              </h2>
-              <ApplicationPipelineChart
-                applications={applications}
-                history={history}
-              />
-            </section>
+            <DashboardLayoutWrapper
+              userId={user.id}
+              userPlan={userPlan}
+              applications={applications}
+              history={history}
+              serverFlagEnabled={isAuditEnabled}
+            />
           </main>
         </div>
       </DashboardWithOnboarding>

--- a/app/(app)/dashboard/settings/page.tsx
+++ b/app/(app)/dashboard/settings/page.tsx
@@ -12,7 +12,7 @@ import { Separator } from "@/components/ui/separator";
 import { getUser, getProfile, getSubscription } from "@/lib/supabase/server";
 import { AccountInfoForm } from "@/components/forms/account-info-form";
 import { SubscriptionManagement } from "@/components/subscription-management";
-import { DangerZone } from "@/components/danger-zone";
+import { DangerZone, DangerZoneCard } from "@/components/danger-zone";
 import { ArrowLeft, Zap } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import ThemeToggle from "@/components/theme-toggle";
@@ -128,17 +128,7 @@ export default async function SettingsPage() {
             <Separator />
 
             {/* Danger Zone */}
-            <Card className="border-red-200">
-              <CardHeader>
-                <CardTitle className="text-red-600">Danger Zone</CardTitle>
-                <CardDescription>
-                  Irreversible and destructive actions
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <DangerZone userId={user.id} subscription={subscription} />
-              </CardContent>
-            </Card>
+            <DangerZoneCard userId={user.id} subscription={subscription} />
           </div>
         </div>
       </div>

--- a/app/(app)/dashboard/upgrade/checkout/page.tsx
+++ b/app/(app)/dashboard/upgrade/checkout/page.tsx
@@ -10,6 +10,7 @@ import { Badge } from "@/components/ui/badge";
 import { ArrowLeft, Loader2, Check } from "lucide-react";
 import { useSupabaseAuth } from "@/hooks/use-supabase-auth";
 import { useSubscription } from "@/hooks/use-subscription";
+import { useFeatureFlag, FEATURE_FLAGS } from "@/lib/hooks/use-feature-flag";
 
 function CheckoutContent() {
   const { user, loading: authLoading } = useSupabaseAuth();
@@ -18,6 +19,7 @@ function CheckoutContent() {
   const searchParams = useSearchParams();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isAuditEnabled = useFeatureFlag(FEATURE_FLAGS.DASHBOARD_UX_AUDIT);
 
   const planId = searchParams.get("planId");
   const billingCycle = searchParams.get("billingCycle") as "monthly" | "yearly";
@@ -174,7 +176,7 @@ function CheckoutContent() {
           </div>
 
           <div className="text-center space-y-2">
-            <h1 className="text-3xl font-bold text-primary">
+            <h1 className="text-3xl font-bold text-foreground">
               Complete Your Subscription
             </h1>
             <p className="text-muted-foreground">
@@ -190,7 +192,7 @@ function CheckoutContent() {
                 <span>{plan.name} Plan</span>
                 <div className="flex items-center gap-2">
                   {discountPercent && (
-                    <Badge variant="secondary" className="bg-green-500/10 text-green-600">
+                    <Badge variant="secondary" className={isAuditEnabled ? "bg-secondary/10 text-secondary" : "bg-green-500/10 text-green-600"}>
                       {discountPercent}% OFF
                     </Badge>
                   )}
@@ -206,7 +208,7 @@ function CheckoutContent() {
               </CardTitle>
               {discountCode && (
                 <div className="mt-2">
-                  <Badge variant="outline" className="text-green-600 border-green-600">
+                  <Badge variant="outline" className={isAuditEnabled ? "text-secondary border-secondary" : "text-green-600 border-green-600"}>
                     Discount Code Applied: {discountCode}
                   </Badge>
                 </div>
@@ -228,7 +230,7 @@ function CheckoutContent() {
           <Card>
             <CardContent className="pt-6">
               {error && (
-                <div className="p-3 text-sm text-red-600 bg-red-50 border border-red-200 rounded-md mb-4 whitespace-pre-wrap">
+                <div className={`p-3 text-sm rounded-md mb-4 whitespace-pre-wrap ${isAuditEnabled ? "text-destructive bg-destructive/10 border border-destructive/20" : "text-red-600 bg-red-50 border border-red-200"}`}>
                   {error}
                 </div>
               )}

--- a/app/(app)/dashboard/upgrade/page.tsx
+++ b/app/(app)/dashboard/upgrade/page.tsx
@@ -292,7 +292,7 @@ export default function UpgradePage() {
           </div>
 
           <div className="text-center space-y-4">
-            <h1 className="text-3xl font-bold text-primary">
+            <h1 className="text-3xl font-bold text-foreground">
               Choose Your Plan
             </h1>
             <p className="text-muted-foreground">
@@ -340,7 +340,7 @@ export default function UpgradePage() {
                   className="text-xs sm:text-sm"
                 >
                   Yearly
-                  <Badge variant="secondary" className="ml-1 sm:ml-2 text-xs">
+                  <Badge className="ml-1 sm:ml-2 text-xs bg-white/20 text-white border-0 hover:bg-white/20">
                     Save 33%
                   </Badge>
                 </Button>
@@ -428,6 +428,7 @@ export default function UpgradePage() {
           </div>
 
           {/* Pricing Cards - 2-tier structure */}
+          {/* AI Coach first on mobile, Free first on desktop */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 max-w-4xl mx-auto">
             {[freePlan, aiCoachPlan].filter(plan => plan && plan.name !== PLAN_NAMES.PRO).map((plan) => {
               if (!plan) return null;
@@ -464,8 +465,9 @@ export default function UpgradePage() {
               
 
               return (
-                <div 
-                  key={plan.id} 
+                <div
+                  key={plan.id}
+                  className={plan.name === PLAN_NAMES.FREE ? "order-last lg:order-first" : "order-first lg:order-last"}
                   onClick={(e) => {
                     // Intercept all clicks on upgrade/downgrade buttons
                     const target = e.target as HTMLElement;
@@ -516,49 +518,30 @@ export default function UpgradePage() {
             <h2 className="text-2xl font-bold text-center text-primary">
               Frequently Asked Questions
             </h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-6xl mx-auto">
-              <Card>
-                <CardHeader>
-                  <CardTitle className="text-lg">
-                    Can I cancel anytime?
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-sm text-muted-foreground">
-                    Yes! You can cancel your subscription at any time. {"We'll"}{" "}
-                    even remind you to cancel when you mark a job as {"'Offer'"}{" "}
-                    to help you save money.
-                  </p>
-                </CardContent>
-              </Card>
-              <Card>
-                <CardHeader>
-                  <CardTitle className="text-lg">
-                    What happens to my data?
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-sm text-muted-foreground">
-                    Your data is always yours. Even if you downgrade to the free
-                    plan, {"you'll"} keep access to your first 100 applications
-                    and all your notes.
-                  </p>
-                </CardContent>
-              </Card>
-              <Card>
-                <CardHeader>
-                  <CardTitle className="text-lg">
-                    How does AI coaching work?
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-sm text-muted-foreground">
-                    Our AI coach uses advanced language models to analyze your
-                    resume, prepare you for interviews, and provide personalized
-                    career advice based on your goals and experience.
-                  </p>
-                </CardContent>
-              </Card>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-4xl mx-auto items-start">
+              {[
+                {
+                  q: "Can I cancel anytime?",
+                  a: "Yes! You can cancel your subscription at any time. We'll even remind you to cancel when you mark a job as 'Offer' to help you save money.",
+                },
+                {
+                  q: "What happens to my data?",
+                  a: "Your data is always yours. Even if you downgrade to the free plan, you'll keep access to your first 100 applications and all your notes.",
+                },
+                {
+                  q: "How does AI coaching work?",
+                  a: "Our AI coach uses advanced language models to analyze your resume, prepare you for interviews, and provide personalized career advice based on your goals and experience.",
+                },
+              ].map((faq, i, arr) => (
+                <Card key={i}>
+                  <CardHeader>
+                    <CardTitle className="text-lg">{faq.q}</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-sm text-muted-foreground">{faq.a}</p>
+                  </CardContent>
+                </Card>
+              ))}
             </div>
           </div>
         </div>

--- a/app/(app)/dashboard/upgrade/success/page.tsx
+++ b/app/(app)/dashboard/upgrade/success/page.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { CheckCircle, ArrowRight } from "lucide-react"
 import { trackLinkedInPurchase } from "@/lib/analytics/linkedin"
 import { trackConversionEvent, CONVERSION_EVENTS } from "@/lib/analytics/conversion-events"
+import { useFeatureFlag, FEATURE_FLAGS } from "@/lib/hooks/use-feature-flag"
 
 export default function UpgradeSuccessPage() {
   const router = useRouter()
@@ -16,6 +17,7 @@ export default function UpgradeSuccessPage() {
   const sessionId = searchParams.get("session_id")
   const [countdown, setCountdown] = useState(5)
   const hasTracked = useRef(false)
+  const isAuditEnabled = useFeatureFlag(FEATURE_FLAGS.DASHBOARD_UX_AUDIT)
 
   // Track purchase conversion once on successful checkout
   useEffect(() => {
@@ -56,19 +58,19 @@ export default function UpgradeSuccessPage() {
         <div className="max-w-2xl mx-auto">
           <Card className="text-center">
             <CardHeader>
-              <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
-                <CheckCircle className="h-8 w-8 text-green-600" />
+              <div className={`mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full ${isAuditEnabled ? "bg-secondary/20" : "bg-green-100"}`}>
+                <CheckCircle className={`h-8 w-8 ${isAuditEnabled ? "text-secondary" : "text-green-600"}`} />
               </div>
-              <CardTitle className="text-2xl">Welcome to Pro! 🎉</CardTitle>
+              <CardTitle className="text-2xl">Welcome to Pro!</CardTitle>
               <CardDescription>
                 Your subscription has been activated successfully. You now have unlimited access to track job
                 applications.
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-6">
-              <div className="bg-green-50 p-4 rounded-lg">
-                <h3 className="font-semibold text-green-900 mb-2">What's included in your AI Coach plan:</h3>
-                <ul className="text-sm text-green-700 space-y-1 text-left">
+              <div className={`p-4 rounded-lg ${isAuditEnabled ? "bg-secondary/10" : "bg-green-50"}`}>
+                <h3 className={`font-semibold mb-2 ${isAuditEnabled ? "text-foreground" : "text-green-900"}`}>What&apos;s included in your AI Coach plan:</h3>
+                <ul className={`text-sm space-y-1 text-left ${isAuditEnabled ? "text-muted-foreground" : "text-green-700"}`}>
                   <li>• Unlimited job applications</li>
                   <li>• AI-powered resume analysis</li>
                   <li>• Interview preparation</li>
@@ -78,8 +80,8 @@ export default function UpgradeSuccessPage() {
                 </ul>
               </div>
 
-              <div className="bg-blue-50 p-4 rounded-lg">
-                <p className="text-blue-800 text-sm">
+              <div className={`p-4 rounded-lg ${isAuditEnabled ? "bg-info/10" : "bg-blue-50"}`}>
+                <p className={`text-sm ${isAuditEnabled ? "text-info-foreground" : "text-blue-800"}`}>
                   Redirecting to your dashboard in <span className="font-bold">{countdown}</span> seconds...
                 </p>
               </div>

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,0 +1,14 @@
+import { Footer } from "@/components/footer";
+
+export default function AppLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      {children}
+      <Footer />
+    </>
+  );
+}

--- a/app/(marketing)/try/unlock/page.tsx
+++ b/app/(marketing)/try/unlock/page.tsx
@@ -5,7 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { JobFitResults } from "@/components/try/job-fit-results";
 import { CoverLetterResults } from "@/components/try/cover-letter-results";
 import { InterviewPrepResults } from "@/components/try/interview-prep-results";
-import { createClient } from "@/lib/supabase/client";
+import { supabase } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Loader2, CheckCircle2, AlertCircle } from "lucide-react";
@@ -36,8 +36,6 @@ export default function UnlockPage() {
       }
 
       try {
-        const supabase = createClient();
-
         // Check if user is authenticated
         const { data: { user }, error: authError } = await supabase.auth.getUser();
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -29,6 +29,13 @@
     --secondary-foreground: 0 0% 100%;
     --destructive: 347 77% 50%;       /* Rose-600 — errors */
     --destructive-foreground: 0 0% 100%;
+    --warning: 33 100% 50%;            /* Amber-500 — warnings */
+    --warning-foreground: 21 100% 32%; /* #E65100 — 6.8:1 on light bg */
+    --info: 210 79% 46%;              /* Blue-600 #1976D2 — info */
+    --info-foreground: 213 100% 33%;  /* #0D47A1 — 7.2:1 on light bg */
+    --ai-brand: 33 100% 50%;          /* Amber/orange for AI features */
+    --ai-brand-foreground: 0 0% 100%;
+    --ai-brand-light: 33 100% 95%;    /* Subtle AI bg */
 
     /* ─── Text ─── */
     --muted: 30 6% 96%;
@@ -96,7 +103,7 @@
     --surface-raised: 220 16% 20%;    /* Surface-3: badges, chips (+4% more) */
 
     /* ─── Brand colors (desaturated 10-15% for dark bg) ─── */
-    --primary: 239 70% 65%;           /* Indigo lighter, less saturated */
+    --primary: 239 70% 75%;           /* Indigo — light enough for dark bg */
     --primary-foreground: 0 0% 100%;
     --accent: 24 90% 55%;             /* Coral slightly lighter */
     --accent-foreground: 0 0% 100%;
@@ -104,6 +111,13 @@
     --secondary-foreground: 0 0% 100%;
     --destructive: 347 65% 58%;       /* Rose desaturated */
     --destructive-foreground: 0 0% 100%;
+    --warning: 33 90% 55%;            /* Amber lighter for dark bg */
+    --warning-foreground: 33 90% 70%; /* Readable on dark surfaces */
+    --info: 210 70% 60%;             /* Blue lighter for dark bg */
+    --info-foreground: 210 70% 75%;  /* Readable on dark surfaces */
+    --ai-brand: 33 90% 55%;          /* Amber/orange lighter */
+    --ai-brand-foreground: 0 0% 100%;
+    --ai-brand-light: 33 50% 15%;    /* Subtle AI bg on dark */
 
     /* ─── Text ─── */
     --muted: 220 14% 16%;

--- a/components/ai-coach-navigation/AICoachTeaser.tsx
+++ b/components/ai-coach-navigation/AICoachTeaser.tsx
@@ -52,18 +52,20 @@ export function AICoachTeaser({
   const { isAuditEnabled } = useDashboardFlags();
   const theme = getAIThemeClasses(isAuditEnabled);
 
+  // Track navigation view
+  useEffect(() => {
+    if (userPlan !== "ai_coach") {
+      aiCoachAnalytics.trackNavigationViewed({
+        subscription_plan: userPlan,
+        user_id: userId,
+      });
+    }
+  }, [userPlan, userId]);
+
   // Don't show teaser to AI Coach users
   if (userPlan === "ai_coach") {
     return null;
   }
-
-  // Track navigation view
-  useEffect(() => {
-    aiCoachAnalytics.trackNavigationViewed({
-      subscription_plan: userPlan,
-      user_id: userId,
-    });
-  }, [userPlan, userId]);
 
   // Handle upgrade click
   const handleUpgradeClick = () => {
@@ -90,7 +92,7 @@ export function AICoachTeaser({
         </div>
         <Button
           variant="outline"
-          size="sm"
+          size="default"
           className="flex-shrink-0"
           onClick={handleUpgradeClick}
           asChild

--- a/components/ai-coach-navigation/AICoachTeaser.tsx
+++ b/components/ai-coach-navigation/AICoachTeaser.tsx
@@ -26,7 +26,8 @@ import {
 import { UI_CONSTANTS } from "@/lib/constants/ui";
 import { APP_ROUTES } from "@/lib/constants/routes";
 import { aiCoachAnalytics } from "@/lib/analytics";
-import { AI_THEME } from "@/lib/constants/ai-theme";
+import { AI_THEME, getAIThemeClasses } from "@/lib/constants/ai-theme";
+import { useDashboardFlags } from "@/components/providers/dashboard-flags-provider";
 import type { Application, PermissionLevel } from "@/types";
 
 interface AICoachTeaserProps {
@@ -34,6 +35,7 @@ interface AICoachTeaserProps {
   recentApplications?: Application[];
   className?: string;
   userId?: string;
+  compact?: boolean;
 }
 
 /**
@@ -45,7 +47,11 @@ export function AICoachTeaser({
   recentApplications = [],
   className,
   userId,
+  compact = false,
 }: AICoachTeaserProps) {
+  const { isAuditEnabled } = useDashboardFlags();
+  const theme = getAIThemeClasses(isAuditEnabled);
+
   // Don't show teaser to AI Coach users
   if (userPlan === "ai_coach") {
     return null;
@@ -62,37 +68,56 @@ export function AICoachTeaser({
   // Handle upgrade click
   const handleUpgradeClick = () => {
     aiCoachAnalytics.trackUpgradeClick({
-      source: "navigation",
+      source: compact ? "navigation_compact" : "navigation",
       subscription_plan: userPlan,
       user_id: userId,
     });
   };
 
-  // Handle preview features click
-  const handlePreviewClick = () => {
-    aiCoachAnalytics.trackFeatureCardClick({
-      feature_name: "preview_features",
-      location: "navigation",
-      subscription_plan: userPlan,
-      user_id: userId,
-    });
-  };
+  if (compact) {
+    return (
+      <div
+        className={`flex items-center justify-between gap-4 p-4 rounded-lg border border-border bg-card ${className}`}
+        data-onboarding="ai-coach-nav"
+      >
+        <div className="flex items-center gap-3 min-w-0">
+          <div className={`p-2 rounded-md ${AI_THEME.classes.background.gradient} flex-shrink-0`}>
+            <Brain className="h-4 w-4 text-white" />
+          </div>
+          <p className="text-sm text-muted-foreground truncate">
+            Get AI-powered resume analysis, interview prep, and career coaching
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          className="flex-shrink-0"
+          onClick={handleUpgradeClick}
+          asChild
+        >
+          <Link href={NAVIGATION_URLS.UPGRADE}>
+            Learn More
+          </Link>
+        </Button>
+      </div>
+    );
+  }
 
   return (
     <Card
-      className={`${AI_THEME.getCardClasses()} ${className}`}
+      className={`${theme.getCardClasses()} ${className}`}
       data-onboarding="ai-coach-nav"
     >
       <CardHeader>
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className={`p-3 rounded-lg ${AI_THEME.classes.background.gradient} flex items-center justify-center`}>
+            <div className={`p-3 rounded-lg ${theme.background.gradient} flex items-center justify-center`}>
               <Brain className="h-6 w-6 text-white" />
             </div>
             <div>
               <CardTitle className="flex items-center gap-2 text-foreground">
                 Unlock AI Career Coach
-                <Badge className={`${AI_THEME.getBadgeClasses()} border-0`}>
+                <Badge className={`${theme.getBadgeClasses()} border-0`}>
                   PRO
                 </Badge>
               </CardTitle>
@@ -101,13 +126,13 @@ export function AICoachTeaser({
               </CardDescription>
             </div>
           </div>
-          <Sparkles className={`h-8 w-8 ${AI_THEME.classes.text.primary} animate-pulse`} />
+          <Sparkles className={`h-8 w-8 ${theme.text.primary} ${isAuditEnabled ? "" : "animate-pulse"}`} />
         </div>
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div className="flex items-center gap-3 p-3 bg-background/60 dark:bg-background/40 border border-border rounded-lg">
-            <Brain className={`h-5 w-5 ${AI_THEME.classes.text.primary}`} />
+            <Brain className={`h-5 w-5 ${theme.text.primary}`} />
             <div>
               <p className="font-medium text-sm text-foreground">
                 Resume Analysis
@@ -118,7 +143,7 @@ export function AICoachTeaser({
             </div>
           </div>
           <div className="flex items-center gap-3 p-3 bg-background/60 dark:bg-background/40 border border-border rounded-lg">
-            <MessageSquare className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+            <MessageSquare className={`h-5 w-5 ${isAuditEnabled ? "text-primary" : "text-blue-600 dark:text-blue-400"}`} />
             <div>
               <p className="font-medium text-sm text-foreground">
                 Interview Prep
@@ -147,7 +172,7 @@ export function AICoachTeaser({
 
         <div className="flex gap-3">
           <Button
-            className={`flex-1 ${AI_THEME.getButtonClasses("primary")} font-semibold shadow-md`}
+            className={`flex-1 ${theme.getButtonClasses("primary")} font-semibold shadow-md`}
             onClick={handleUpgradeClick}
             asChild
           >
@@ -156,17 +181,6 @@ export function AICoachTeaser({
               Upgrade Now
             </Link>
           </Button>
-          {/* <Button 
-            variant="outline" 
-            className="border-border hover:bg-accent hover:text-accent-foreground"
-            onClick={handlePreviewClick}
-            asChild
-          >
-            <Link href={NAVIGATION_URLS.AI_COACH}>
-              Preview Features
-              <ArrowRight className="h-4 w-4 ml-2" />
-            </Link>
-          </Button> */}
         </div>
       </CardContent>
     </Card>

--- a/components/ai-coach-navigation/AICoachTeaser.tsx
+++ b/components/ai-coach-navigation/AICoachTeaser.tsx
@@ -81,7 +81,7 @@ export function AICoachTeaser({
         data-onboarding="ai-coach-nav"
       >
         <div className="flex items-center gap-3 min-w-0">
-          <div className={`p-2 rounded-md ${AI_THEME.classes.background.gradient} flex-shrink-0`}>
+          <div className={`p-2 rounded-md ${theme.background.gradient} flex-shrink-0`}>
             <Brain className="h-4 w-4 text-white" />
           </div>
           <p className="text-sm text-muted-foreground truncate">

--- a/components/ai-coach-navigation/index.tsx
+++ b/components/ai-coach-navigation/index.tsx
@@ -9,24 +9,26 @@ interface AICoachDashboardIntegrationProps {
   recentApplications?: Application[];
   className?: string;
   userId?: string;
+  compact?: boolean;
 }
 
 /**
  * Main integration component that shows appropriate AI Coach content
  * based on user's subscription level
  */
-export function AICoachDashboardIntegration({ 
-  userPlan, 
-  recentApplications = [], 
+export function AICoachDashboardIntegration({
+  userPlan,
+  recentApplications = [],
   className,
-  userId
+  userId,
+  compact = false,
 }: AICoachDashboardIntegrationProps) {
   // Show quick actions for AI Coach subscribers
   if (userPlan === "ai_coach") {
     return (
-      <AICoachQuickActions 
-        recentApplications={recentApplications} 
-        className={className} 
+      <AICoachQuickActions
+        recentApplications={recentApplications}
+        className={className}
         userId={userId}
       />
     );
@@ -34,11 +36,12 @@ export function AICoachDashboardIntegration({
 
   // Show teaser for non-subscribers
   return (
-    <AICoachTeaser 
+    <AICoachTeaser
       userPlan={userPlan}
-      recentApplications={recentApplications} 
-      className={className} 
+      recentApplications={recentApplications}
+      className={className}
       userId={userId}
+      compact={compact}
     />
   );
 }

--- a/components/ai-coach/ai-coach-dashboard.tsx
+++ b/components/ai-coach/ai-coach-dashboard.tsx
@@ -121,7 +121,7 @@ function AICoachDashboardInner({ userId }: AICoachDashboardProps) {
         className="space-y-6"
       >
         <div className="flex items-center justify-between gap-3 flex-wrap">
-          <TabsList className="grid grid-cols-3 sm:flex sm:flex-wrap md:grid md:grid-cols-5 flex-1 h-auto p-1 gap-1">
+          <TabsList className="grid grid-cols-5 flex-1 h-auto p-1 gap-1">
           <TabsTrigger value="resume" className="flex flex-col sm:flex-row items-center justify-center gap-1 sm:gap-2 px-2 py-3 sm:py-2 min-w-[60px] sm:min-w-[80px]">
             <FileText className="h-4 w-4 flex-shrink-0" />
             <span className="text-[10px] sm:text-xs md:text-sm leading-tight text-center">Resume</span>

--- a/components/ai-coach/career-advice.tsx
+++ b/components/ai-coach/career-advice.tsx
@@ -444,8 +444,8 @@ export function CareerAdvice() {
 
   return (
     <div className="flex gap-6 h-[calc(100vh-12rem)]">
-      {/* Sidebar */}
-      <Card className="w-72 flex flex-col shrink-0">
+      {/* Sidebar - hidden on mobile */}
+      <Card className="w-72 flex-col shrink-0 hidden md:flex">
         <CardHeader className="pb-3">
           <div className="flex items-center justify-between">
             <CardTitle className="text-sm font-medium">Conversations</CardTitle>

--- a/components/application-pipeline-chart.tsx
+++ b/components/application-pipeline-chart.tsx
@@ -91,7 +91,7 @@ export function ApplicationPipelineChart({
               <p>No applications to display yet.</p>
               {isAuditEnabled && (
                 <Link href="/dashboard/add">
-                  <Button variant="outline" size="sm">
+                  <Button variant="outline" className="min-h-11 px-4">
                     <Plus className="h-4 w-4 mr-2" />
                     Add Your First Application
                   </Button>

--- a/components/application-pipeline-chart.tsx
+++ b/components/application-pipeline-chart.tsx
@@ -17,6 +17,10 @@ import {
 } from "@/lib/pipeline-utils";
 import { useOnboarding } from '@/lib/onboarding/context';
 import { FakeOnboardingPipelineChart } from './onboarding/fake-pipeline-chart';
+import { useDashboardFlags } from "@/components/providers/dashboard-flags-provider";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Plus } from "lucide-react";
 
 // Dynamically import Plotly to avoid SSR issues
 const Plot = dynamic(() => import("react-plotly.js"), { ssr: false });
@@ -47,6 +51,7 @@ export function ApplicationPipelineChart({
   // Check if we're in any onboarding flow (show fake chart during onboarding)
   const isInOnboarding = currentFlow !== null;
   const isOnboardingPipelineStep = currentStep?.id === 'view-pipeline';
+  const { isAuditEnabled } = useDashboardFlags();
 
   useEffect(() => {
     setMounted(true);
@@ -82,15 +87,25 @@ export function ApplicationPipelineChart({
           {isInOnboarding ? (
             <FakeOnboardingPipelineChart />
           ) : (
-            <div className="h-[400px] flex items-center justify-center text-muted-foreground">
-              No applications to display. Add your first application to see the
-              pipeline visualization.
+            <div className={`${isAuditEnabled ? "h-[200px]" : "h-[400px]"} flex flex-col items-center justify-center text-muted-foreground gap-3`}>
+              <p>No applications to display yet.</p>
+              {isAuditEnabled && (
+                <Link href="/dashboard/add">
+                  <Button variant="outline" size="sm">
+                    <Plus className="h-4 w-4 mr-2" />
+                    Add Your First Application
+                  </Button>
+                </Link>
+              )}
             </div>
           )}
         </CardContent>
       </Card>
     );
   }
+
+  // When audit enabled and very few applications, show a hint
+  const showSparseHint = isAuditEnabled && applications.length < 4;
 
   // Define the pipeline stages in order (must match database schema)
   // "Awaiting Response" is a terminal node for apps still at Applied
@@ -254,6 +269,11 @@ export function ApplicationPipelineChart({
             style={{ width: "100%", height: "100%" }}
           />
         </div>
+        {showSparseHint && (
+          <p className="text-xs text-muted-foreground text-center mt-2">
+            Add more applications to see a richer pipeline visualization.
+          </p>
+        )}
       </CardContent>
     </Card>
   );

--- a/components/application-pipeline-chart.tsx
+++ b/components/application-pipeline-chart.tsx
@@ -90,12 +90,12 @@ export function ApplicationPipelineChart({
             <div className={`${isAuditEnabled ? "h-[200px]" : "h-[400px]"} flex flex-col items-center justify-center text-muted-foreground gap-3`}>
               <p>No applications to display yet.</p>
               {isAuditEnabled && (
-                <Link href="/dashboard/add">
-                  <Button variant="outline" className="min-h-11 px-4">
+                <Button variant="outline" className="min-h-11 px-4" asChild>
+                  <Link href="/dashboard/add">
                     <Plus className="h-4 w-4 mr-2" />
                     Add Your First Application
-                  </Button>
-                </Link>
+                  </Link>
+                </Button>
               )}
             </div>
           )}

--- a/components/danger-zone.tsx
+++ b/components/danger-zone.tsx
@@ -14,12 +14,37 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { AlertTriangle, Trash2, Loader2 } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { deleteAccountAction } from "@/lib/actions";
+import { useFeatureFlag, FEATURE_FLAGS } from "@/lib/hooks/use-feature-flag";
 import type { UserSubscription } from "@/lib/supabase";
 
 interface DangerZoneProps {
   userId: string;
   subscription: UserSubscription | null;
+}
+
+export function DangerZoneCard({ userId, subscription }: DangerZoneProps) {
+  const isAuditEnabled = useFeatureFlag(FEATURE_FLAGS.DASHBOARD_UX_AUDIT);
+  return (
+    <Card className={isAuditEnabled ? "border-destructive/20" : "border-red-200"}>
+      <CardHeader>
+        <CardTitle className={isAuditEnabled ? "text-destructive" : "text-red-600"}>Danger Zone</CardTitle>
+        <CardDescription>
+          Irreversible and destructive actions
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <DangerZone userId={userId} subscription={subscription} />
+      </CardContent>
+    </Card>
+  );
 }
 
 export function DangerZone({ userId, subscription }: DangerZoneProps) {
@@ -34,6 +59,7 @@ export function DangerZone({ userId, subscription }: DangerZoneProps) {
     subscription?.subscription_plans?.name !== "Free" &&
     subscription?.status === "active";
   const confirmationText = "DELETE MY ACCOUNT";
+  const isAuditEnabled = useFeatureFlag(FEATURE_FLAGS.DASHBOARD_UX_AUDIT);
 
   const handleDeleteAccount = async () => {
     if (confirmText !== confirmationText) return;
@@ -68,21 +94,21 @@ export function DangerZone({ userId, subscription }: DangerZoneProps) {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-start gap-3 p-4 border border-red-200 rounded-lg bg-red-50">
-        <AlertTriangle className="h-5 w-5 text-red-600 mt-0.5 flex-shrink-0" />
+      <div className={`flex items-start gap-3 p-4 rounded-lg ${isAuditEnabled ? "border border-destructive/20 bg-destructive/5" : "border border-red-200 bg-red-50"}`}>
+        <AlertTriangle className={`h-5 w-5 mt-0.5 flex-shrink-0 ${isAuditEnabled ? "text-destructive" : "text-red-600"}`} />
         <div className="space-y-2">
-          <h3 className="font-semibold text-red-900">Delete Account</h3>
-          <p className="text-sm text-red-700">
+          <h3 className={`font-semibold ${isAuditEnabled ? "text-foreground" : "text-red-900"}`}>Delete Account</h3>
+          <p className={`text-sm ${isAuditEnabled ? "text-muted-foreground" : "text-red-700"}`}>
             Permanently delete your account and all associated data. This action
             cannot be undone.
           </p>
           {isOnPaidPlan && (
-            <p className="text-sm text-red-700 font-medium">
-              ⚠️ You have an active subscription that will be canceled
+            <p className={`text-sm font-medium ${isAuditEnabled ? "text-destructive" : "text-red-700"}`}>
+              You have an active subscription that will be canceled
               immediately.
             </p>
           )}
-          <ul className="text-xs text-red-600 space-y-1 ml-4">
+          <ul className={`text-xs space-y-1 ml-4 ${isAuditEnabled ? "text-destructive" : "text-red-600"}`}>
             <li>• All your job applications and notes will be deleted</li>
             <li>• Your LinkedIn contacts will be removed</li>
             <li>• Your subscription will be canceled (if active)</li>
@@ -93,14 +119,14 @@ export function DangerZone({ userId, subscription }: DangerZoneProps) {
 
       <Dialog open={isOpen} onOpenChange={setIsOpen}>
         <DialogTrigger asChild>
-          <Button variant="destructive" className="bg-red-600 hover:bg-red-700">
+          <Button variant="destructive" className={isAuditEnabled ? "" : "bg-red-600 hover:bg-red-700"}>
             <Trash2 className="h-4 w-4 mr-2" />
             Delete Account
           </Button>
         </DialogTrigger>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle className="flex items-center gap-2 text-red-600">
+            <DialogTitle className={`flex items-center gap-2 ${isAuditEnabled ? "text-destructive" : "text-red-600"}`}>
               <AlertTriangle className="h-5 w-5" />
               Delete Account
             </DialogTitle>
@@ -110,7 +136,7 @@ export function DangerZone({ userId, subscription }: DangerZoneProps) {
                 data.
               </p>
               {isOnPaidPlan && (
-                <p className="text-red-600 font-medium">
+                <p className={`font-medium ${isAuditEnabled ? "text-destructive" : "text-red-600"}`}>
                   Your active subscription will be canceled immediately.
                 </p>
               )}
@@ -137,7 +163,7 @@ export function DangerZone({ userId, subscription }: DangerZoneProps) {
               variant="destructive"
               onClick={handleDeleteAccount}
               disabled={confirmText !== confirmationText || loading}
-              className="w-full bg-red-600 hover:bg-red-700"
+              className={`w-full ${isAuditEnabled ? "" : "bg-red-600 hover:bg-red-700"}`}
             >
               {loading ? (
                 <>

--- a/components/dashboard-applications-list.tsx
+++ b/components/dashboard-applications-list.tsx
@@ -101,7 +101,7 @@ export function DashboardApplicationsList({
       <CardHeader>
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
-            <CardTitle className="text-primary text-lg sm:text-xl">Applications</CardTitle>
+            <CardTitle className="text-foreground text-lg sm:text-xl">Applications</CardTitle>
             <CardDescription>
               Track and manage your job applications
             </CardDescription>

--- a/components/dashboard-layout-wrapper.tsx
+++ b/components/dashboard-layout-wrapper.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { AICoachDashboardIntegration } from "@/components/ai-coach-navigation";
+import {
+  NavigationErrorBoundary,
+  AICoachFallback,
+} from "@/components/NavigationErrorBoundary";
+import { DashboardApplicationsList } from "@/components/dashboard-applications-list";
+import { DashboardStats } from "@/components/dashboard-stats";
+import { ApplicationPipelineChart } from "@/components/application-pipeline-chart";
+import { APPLICATION_LIMITS } from "@/lib/constants/navigation";
+import { DashboardFlagsProvider } from "@/components/providers/dashboard-flags-provider";
+import type { Application, ApplicationHistory, PermissionLevel } from "@/types";
+
+interface DashboardLayoutWrapperProps {
+  userId: string;
+  userPlan: PermissionLevel;
+  applications: Application[];
+  history: ApplicationHistory[];
+  /** Evaluated server-side to avoid flash of content */
+  serverFlagEnabled: boolean;
+}
+
+export function DashboardLayoutWrapper({
+  userId,
+  userPlan,
+  applications,
+  history,
+  serverFlagEnabled,
+}: DashboardLayoutWrapperProps) {
+  const recentApplications = applications.slice(
+    0,
+    APPLICATION_LIMITS.DASHBOARD_DISPLAY
+  );
+
+  const flags = { isAuditEnabled: serverFlagEnabled };
+
+  if (serverFlagEnabled) {
+    // New layout: Stats > Apps > Pipeline > AI Coach (compact, at bottom)
+    return (
+      <DashboardFlagsProvider flags={flags}>
+        <DashboardStats userId={userId} />
+
+        <section aria-labelledby="applications-heading">
+          <h2 id="applications-heading" className="sr-only">
+            Recent Applications
+          </h2>
+          <DashboardApplicationsList
+            userId={userId}
+            initialApplications={applications}
+            initialTotal={applications.length}
+          />
+        </section>
+
+        <section aria-labelledby="chart-heading">
+          <h2 id="chart-heading" className="sr-only">
+            Application Pipeline Visualization
+          </h2>
+          <ApplicationPipelineChart
+            applications={applications}
+            history={history}
+          />
+        </section>
+
+        <NavigationErrorBoundary fallback={<AICoachFallback />}>
+          <AICoachDashboardIntegration
+            userPlan={userPlan}
+            recentApplications={recentApplications}
+            userId={userId}
+            compact
+          />
+        </NavigationErrorBoundary>
+      </DashboardFlagsProvider>
+    );
+  }
+
+  // Original layout: Stats > AI Coach > Apps > Pipeline
+  return (
+    <DashboardFlagsProvider flags={flags}>
+      <DashboardStats userId={userId} />
+
+      <NavigationErrorBoundary fallback={<AICoachFallback />}>
+        <AICoachDashboardIntegration
+          userPlan={userPlan}
+          recentApplications={recentApplications}
+          userId={userId}
+        />
+      </NavigationErrorBoundary>
+
+      <section aria-labelledby="applications-heading">
+        <h2 id="applications-heading" className="sr-only">
+          Recent Applications
+        </h2>
+        <DashboardApplicationsList
+          userId={userId}
+          initialApplications={applications}
+          initialTotal={applications.length}
+        />
+      </section>
+
+      <section aria-labelledby="chart-heading">
+        <h2 id="chart-heading" className="sr-only">
+          Application Pipeline Visualization
+        </h2>
+        <ApplicationPipelineChart
+          applications={applications}
+          history={history}
+        />
+      </section>
+    </DashboardFlagsProvider>
+  );
+}

--- a/components/dashboard/ai-features/ai-feature-locked-overlay.tsx
+++ b/components/dashboard/ai-features/ai-feature-locked-overlay.tsx
@@ -6,6 +6,7 @@ import { useNavigation } from "@/lib/utils/navigation";
 import { cn } from "@/lib/utils";
 import { AI_THEME } from "@/lib/constants/ai-theme";
 import { capturePostHogEvent } from "@/lib/analytics/posthog";
+import { useDashboardFlags } from "@/components/providers/dashboard-flags-provider";
 
 interface AIFeatureLockedOverlayProps {
   feature: string;
@@ -19,6 +20,7 @@ export function AIFeatureLockedOverlay({
   onUpgradeClick,
 }: AIFeatureLockedOverlayProps) {
   const { navigateToUpgrade } = useNavigation();
+  const { isAuditEnabled } = useDashboardFlags();
 
   const handleClick = () => {
     capturePostHogEvent("ai_feature_unlock_clicked", {
@@ -36,7 +38,10 @@ export function AIFeatureLockedOverlay({
   return (
     <div
       className={cn(
-        "absolute inset-0 bg-background/80 backdrop-blur-sm z-10 flex items-center justify-center",
+        "absolute inset-0 z-10 flex items-center justify-center",
+        isAuditEnabled
+          ? "bg-background/60"
+          : "bg-background/80 backdrop-blur-sm",
         className
       )}
     >
@@ -47,19 +52,20 @@ export function AIFeatureLockedOverlay({
             <Crown className={`h-5 w-5 ${AI_THEME.classes.text.primary} absolute -top-1 -right-1`} />
           </div>
         </div>
-        
+
         <h3 className="font-semibold text-lg mb-2">
           Unlock {feature} with AI Coach
         </h3>
-        
+
         <p className="text-sm text-muted-foreground mb-4">
           Get instant AI-powered insights to accelerate your job search
         </p>
-        
-        <Button 
-          onClick={handleClick} 
+
+        <Button
+          onClick={handleClick}
           size="sm"
-          className={AI_THEME.getButtonClasses("primary")}
+          className={isAuditEnabled ? "" : AI_THEME.getButtonClasses("primary")}
+          variant={isAuditEnabled ? "default" : undefined}
         >
           <Crown className="h-4 w-4 mr-1" />
           Upgrade to AI Coach

--- a/components/dashboard/ai-features/ai-upgrade-banner.tsx
+++ b/components/dashboard/ai-features/ai-upgrade-banner.tsx
@@ -66,13 +66,14 @@ export function AIUpgradeBanner({ className, variant = "default" }: AIUpgradeBan
       const timer = setTimeout(() => {
         setIsVisible(true);
         capturePostHogEvent("ai_upgrade_banner_shown", {
-          message: BANNER_MESSAGES[messageIndex].title,
+          message: BANNER_MESSAGES[0].title,
           variant,
         });
       }, 2000);
       return () => clearTimeout(timer);
     }
-  }, [messageIndex, variant, isAuditEnabled, dismissDuration]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [variant, isAuditEnabled, dismissDuration]);
 
   useEffect(() => {
     // Only rotate messages when audit flag is off

--- a/components/dashboard/ai-features/ai-upgrade-banner.tsx
+++ b/components/dashboard/ai-features/ai-upgrade-banner.tsx
@@ -7,6 +7,7 @@ import { useNavigation } from "@/lib/utils/navigation";
 import { cn } from "@/lib/utils";
 import { AI_THEME } from "@/lib/constants/ai-theme";
 import { capturePostHogEvent } from "@/lib/analytics/posthog";
+import { useDashboardFlags } from "@/components/providers/dashboard-flags-provider";
 
 interface AIUpgradeBannerProps {
   className?: string;
@@ -31,12 +32,16 @@ const BANNER_MESSAGES = [
   },
 ];
 
-const DISMISS_DURATION = 7 * 24 * 60 * 60 * 1000; // 7 days in milliseconds
+const DISMISS_DURATION_DEFAULT = 7 * 24 * 60 * 60 * 1000; // 7 days
+const DISMISS_DURATION_LONG = 30 * 24 * 60 * 60 * 1000; // 30 days
 
 export function AIUpgradeBanner({ className, variant = "default" }: AIUpgradeBannerProps) {
   const [isVisible, setIsVisible] = useState(false);
   const [messageIndex, setMessageIndex] = useState(0);
   const { navigateToUpgrade } = useNavigation();
+  const { isAuditEnabled } = useDashboardFlags();
+
+  const dismissDuration = isAuditEnabled ? DISMISS_DURATION_LONG : DISMISS_DURATION_DEFAULT;
 
   useEffect(() => {
     // Check if banner was dismissed recently
@@ -44,33 +49,41 @@ export function AIUpgradeBanner({ className, variant = "default" }: AIUpgradeBan
     if (dismissedAt) {
       const dismissTime = new Date(dismissedAt).getTime();
       const now = new Date().getTime();
-      if (now - dismissTime < DISMISS_DURATION) {
+      if (now - dismissTime < dismissDuration) {
         return;
       }
     }
 
-    // Show banner after a short delay
-    const timer = setTimeout(() => {
+    if (isAuditEnabled) {
+      // Show immediately (no delay) when audit flag is on
       setIsVisible(true);
-
-      // Track banner impression
       capturePostHogEvent("ai_upgrade_banner_shown", {
-        message: BANNER_MESSAGES[messageIndex].title,
+        message: BANNER_MESSAGES[0].title,
         variant,
       });
-    }, 2000);
-
-    return () => clearTimeout(timer);
-  }, [messageIndex, variant]);
+    } else {
+      // Show banner after a short delay
+      const timer = setTimeout(() => {
+        setIsVisible(true);
+        capturePostHogEvent("ai_upgrade_banner_shown", {
+          message: BANNER_MESSAGES[messageIndex].title,
+          variant,
+        });
+      }, 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [messageIndex, variant, isAuditEnabled, dismissDuration]);
 
   useEffect(() => {
-    // Rotate messages every 10 seconds
+    // Only rotate messages when audit flag is off
+    if (isAuditEnabled) return;
+
     const interval = setInterval(() => {
       setMessageIndex((prev) => (prev + 1) % BANNER_MESSAGES.length);
     }, 10000);
 
     return () => clearInterval(interval);
-  }, []);
+  }, [isAuditEnabled]);
 
   const handleDismiss = () => {
     setIsVisible(false);
@@ -165,10 +178,12 @@ export function AIUpgradeBanner({ className, variant = "default" }: AIUpgradeBan
         </div>
       </div>
       
-      {/* Animated background effect */}
-      <div className="absolute inset-0 opacity-10">
-        <div className="absolute -inset-40 bg-gradient-to-r from-amber-400/50 to-orange-400/50 blur-3xl animate-pulse" />
-      </div>
+      {/* Animated background effect — hidden when audit flag is on */}
+      {!isAuditEnabled && (
+        <div className="absolute inset-0 opacity-10">
+          <div className="absolute -inset-40 bg-gradient-to-r from-amber-400/50 to-orange-400/50 blur-3xl animate-pulse" />
+        </div>
+      )}
     </div>
   );
 }

--- a/components/dashboard/application-usage-display.tsx
+++ b/components/dashboard/application-usage-display.tsx
@@ -3,6 +3,7 @@
 import { Progress } from "@/components/ui/progress";
 import { cn } from "@/lib/utils";
 import { Info } from "lucide-react";
+import { useDashboardFlags } from "@/components/providers/dashboard-flags-provider";
 import {
   Tooltip,
   TooltipContent,
@@ -26,6 +27,7 @@ export function ApplicationUsageDisplay({
   const percentage = (currentCount / limit) * 100;
   const isNearLimit = percentage >= 80;
   const isAtLimit = currentCount >= limit;
+  const { isAuditEnabled } = useDashboardFlags();
 
   if (variant === "compact") {
     return (
@@ -57,20 +59,20 @@ export function ApplicationUsageDisplay({
           </div>
           
           <div className="space-y-2">
-            <Progress 
-              value={percentage} 
+            <Progress
+              value={percentage}
               className={cn(
                 "h-2",
-                isAtLimit && "bg-red-100",
-                isNearLimit && !isAtLimit && "bg-orange-100"
+                isAtLimit && (isAuditEnabled ? "bg-destructive/10" : "bg-red-100"),
+                isNearLimit && !isAtLimit && (isAuditEnabled ? "bg-warning/10" : "bg-orange-100")
               )}
             />
-            
+
             <div className="flex items-center justify-between text-sm">
               <span className={cn(
                 "font-medium",
-                isAtLimit && "text-red-600",
-                isNearLimit && !isAtLimit && "text-orange-600"
+                isAtLimit && (isAuditEnabled ? "text-destructive" : "text-red-600"),
+                isNearLimit && !isAtLimit && (isAuditEnabled ? "text-warning-foreground" : "text-orange-600")
               )}>
                 {currentCount} / {limit} applications used
               </span>
@@ -81,13 +83,13 @@ export function ApplicationUsageDisplay({
           </div>
           
           {isNearLimit && !isAtLimit && (
-            <p className="text-xs text-orange-600 mt-2">
-              You're approaching your application limit. Consider upgrading for unlimited tracking.
+            <p className={`text-xs mt-2 ${isAuditEnabled ? "text-warning-foreground" : "text-orange-600"}`}>
+              You&apos;re approaching your application limit. Consider upgrading for unlimited tracking.
             </p>
           )}
-          
+
           {isAtLimit && (
-            <p className="text-xs text-red-600 mt-2">
+            <p className={`text-xs mt-2 ${isAuditEnabled ? "text-destructive" : "text-red-600"}`}>
               You've reached your application limit. Upgrade to continue tracking new applications.
             </p>
           )}
@@ -103,8 +105,8 @@ export function ApplicationUsageDisplay({
         <span className="text-muted-foreground">Applications</span>
         <span className={cn(
           "font-medium",
-          isAtLimit && "text-red-600",
-          isNearLimit && !isAtLimit && "text-orange-600"
+          isAtLimit && (isAuditEnabled ? "text-destructive" : "text-red-600"),
+          isNearLimit && !isAtLimit && (isAuditEnabled ? "text-warning-foreground" : "text-orange-600")
         )}>
           {currentCount} / {limit}
         </span>

--- a/components/mobile-navigation.tsx
+++ b/components/mobile-navigation.tsx
@@ -33,7 +33,7 @@ import { UI_CONSTANTS } from "@/lib/constants/ui";
 import type { User as SupabaseUser } from "@supabase/supabase-js";
 import type { Profile } from "@/lib/supabase";
 import type { PermissionLevel } from "@/types";
-import { NavItemTag } from "@/components/ui/nav-item-tag";
+
 
 interface MobileNavigationProps {
   user: SupabaseUser;
@@ -55,9 +55,6 @@ export function MobileNavigation({
   const pathname = usePathname();
   const router = useRouter();
   
-  // Resume Roast "new" tag expires 6 months from launch (March 22, 2026)
-  const resumeRoastNewTagExpiry = new Date('2026-03-22');
-
   const handleSignOut = async () => {
     setLoading(true);
     try {
@@ -83,13 +80,13 @@ export function MobileNavigation({
         <Button
           variant="ghost"
           size="icon"
-          className="md:hidden"
+          className="md:hidden -mr-2"
           aria-label="Open menu"
         >
           <Menu className="h-5 w-5" />
         </Button>
       </SheetTrigger>
-      <SheetContent side="left" className="w-[280px] sm:w-[350px]">
+      <SheetContent side="right" className="w-[280px] sm:w-[350px]">
         <SheetHeader>
           <SheetTitle>Menu</SheetTitle>
         </SheetHeader>

--- a/components/navigation-client.tsx
+++ b/components/navigation-client.tsx
@@ -105,7 +105,7 @@ export function NavigationClient() {
             height={24}
             className="h-6 w-6"
           />
-          <span className="font-bold text-xl text-primary">AppTrack</span>
+          <span className="font-bold text-xl text-foreground">AppTrack</span>
         </Link>
 
         <div className="ml-auto flex items-center space-x-2">

--- a/components/navigation-client.tsx
+++ b/components/navigation-client.tsx
@@ -14,15 +14,13 @@ import {
 import { User, LogOut, Crown, Shield, Flame } from "lucide-react";
 import { useSupabaseAuth } from "@/hooks/use-supabase-auth";
 import { useSubscription } from "@/hooks/use-subscription";
-import { NavItemTag } from "@/components/ui/nav-item-tag";
+
 
 export function NavigationClient() {
   const { user, profile, signOut } = useSupabaseAuth();
   const { isOnFreePlan } = useSubscription(user?.id || null);
   const [isAdmin, setIsAdmin] = useState(false);
   
-  // Resume Roast "new" tag expires 6 months from launch (March 22, 2026)
-  const resumeRoastNewTagExpiry = new Date('2026-03-22');
 
   // Check if user is admin
   useEffect(() => {
@@ -81,7 +79,7 @@ export function NavigationClient() {
               height={24}
               className="h-6 w-6"
             />
-            <span className="font-bold text-xl text-primary">AppTrack</span>
+            <span className="font-bold text-xl text-foreground">AppTrack</span>
           </Link>
           <div className="ml-auto flex items-center space-x-4">
             <Button variant="ghost" asChild>
@@ -153,14 +151,7 @@ export function NavigationClient() {
               <Link href="/roast-my-resume">
                 <DropdownMenuItem>
                   <Flame className="h-4 w-4 mr-2" />
-                  <span className="flex items-center gap-1">
-                    Resume Roast
-                    <NavItemTag 
-                      label="new" 
-                      variant="new" 
-                      expiresAt={resumeRoastNewTagExpiry}
-                    />
-                  </span>
+                  Resume Roast
                 </DropdownMenuItem>
               </Link>
 

--- a/components/navigation-server.tsx
+++ b/components/navigation-server.tsx
@@ -44,7 +44,7 @@ export async function NavigationServer({ variant = "default" }: NavigationServer
   return (
     <header className="border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       {/* Top Header */}
-      <nav aria-label="Site header" className="container flex h-14 items-center">
+      <nav aria-label="Site header" className="container flex h-14 items-center px-4 sm:px-8">
         <Link href="/dashboard" className="mr-6 flex items-center space-x-2" aria-label="AppTrack Dashboard">
           <Image
             src="/logo_square.png"
@@ -53,10 +53,10 @@ export async function NavigationServer({ variant = "default" }: NavigationServer
             height={24}
             className="h-6 w-6"
           />
-          <span className="font-bold text-xl text-primary">AppTrack</span>
+          <span className="font-bold text-xl text-foreground">AppTrack</span>
         </Link>
 
-        <div className="ml-auto flex items-center space-x-2 sm:space-x-3" role="toolbar" aria-label="User actions">
+        <div className="ml-auto flex items-center gap-2 sm:gap-3" role="toolbar" aria-label="User actions">
           {/* Mobile Navigation Menu */}
           <MobileNavigation 
             user={user} 

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -5,7 +5,7 @@ import Image from "next/image"
 import { Button } from "@/components/ui/button"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, DropdownMenuSeparator } from "@/components/ui/dropdown-menu"
 import { User, LogOut, Crown, Flame, BarChart3 } from "lucide-react"
-import { NavItemTag } from "@/components/ui/nav-item-tag"
+
 import { useSupabaseAuthSimple } from "@/hooks/use-supabase-auth-simple"
 import { useSubscription } from "@/hooks/use-subscription"
 
@@ -13,8 +13,6 @@ export function Navigation() {
   const { user, profile, signOut } = useSupabaseAuthSimple()
   const { isOnFreePlan } = useSubscription(user?.id || null)
   
-  // Resume Roast "new" tag expires 6 months from launch (March 22, 2026)
-  const resumeRoastNewTagExpiry = new Date('2026-03-22')
 
   const handleLogout = async () => {
     await signOut()
@@ -111,14 +109,7 @@ export function Navigation() {
               <Link href="/roast-my-resume">
                 <DropdownMenuItem>
                   <Flame className="h-4 w-4 mr-2" />
-                  <span className="flex items-center gap-1">
-                    Resume Roast
-                    <NavItemTag 
-                      label="new" 
-                      variant="new" 
-                      expiresAt={resumeRoastNewTagExpiry}
-                    />
-                  </span>
+                  Resume Roast
                 </DropdownMenuItem>
               </Link>
 

--- a/components/providers/dashboard-flags-provider.tsx
+++ b/components/providers/dashboard-flags-provider.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+interface DashboardFlags {
+  isAuditEnabled: boolean;
+}
+
+const DashboardFlagsContext = createContext<DashboardFlags>({
+  isAuditEnabled: false,
+});
+
+export function DashboardFlagsProvider({
+  children,
+  flags,
+}: {
+  children: React.ReactNode;
+  flags: DashboardFlags;
+}) {
+  return (
+    <DashboardFlagsContext.Provider value={flags}>
+      {children}
+    </DashboardFlagsContext.Provider>
+  );
+}
+
+export function useDashboardFlags() {
+  return useContext(DashboardFlagsContext);
+}

--- a/components/providers/dashboard-flags-provider.tsx
+++ b/components/providers/dashboard-flags-provider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext } from "react";
+import { createContext, useContext, useState, useEffect } from "react";
 
 interface DashboardFlags {
   isAuditEnabled: boolean;
@@ -10,6 +10,11 @@ const DashboardFlagsContext = createContext<DashboardFlags>({
   isAuditEnabled: false,
 });
 
+/**
+ * Provides feature flag values to dashboard child components.
+ * Server-side flag is the initial value; client-side localStorage
+ * overrides are reconciled on mount for local dev testing.
+ */
 export function DashboardFlagsProvider({
   children,
   flags,
@@ -17,8 +22,23 @@ export function DashboardFlagsProvider({
   children: React.ReactNode;
   flags: DashboardFlags;
 }) {
+  const [resolved, setResolved] = useState(flags);
+
+  useEffect(() => {
+    try {
+      const local = localStorage.getItem("ff:dashboard-ux-audit-v1");
+      if (local === "true") {
+        setResolved({ isAuditEnabled: true });
+      } else if (local === "false") {
+        setResolved({ isAuditEnabled: false });
+      }
+    } catch {
+      // localStorage unavailable
+    }
+  }, []);
+
   return (
-    <DashboardFlagsContext.Provider value={flags}>
+    <DashboardFlagsContext.Provider value={resolved}>
       {children}
     </DashboardFlagsContext.Provider>
   );

--- a/components/subscription-management.tsx
+++ b/components/subscription-management.tsx
@@ -23,6 +23,7 @@ import {
   AlertDialogAction,
 } from "@/components/ui/alert-dialog";
 import { formatLocalDate } from "@/lib/utils/date";
+import { useFeatureFlag, FEATURE_FLAGS } from "@/lib/hooks/use-feature-flag";
 
 interface SubscriptionManagementProps {
   userId: string;
@@ -41,6 +42,7 @@ export function SubscriptionManagement({
   const [confirmCancelOpen, setConfirmCancelOpen] = useState(false);
   const [successModalOpen, setSuccessModalOpen] = useState(false);
   const [successMessage, setSuccessMessage] = useState("");
+  const isAuditEnabled = useFeatureFlag(FEATURE_FLAGS.DASHBOARD_UX_AUDIT);
 
   const isOnFreePlan =
     subscription?.subscription_plans?.name === "Free" || !subscription;
@@ -154,14 +156,12 @@ export function SubscriptionManagement({
         </CardHeader>
         <CardContent>
           <ul className="space-y-2">
-            {subscription?.subscription_plans?.features.map(
-              (feature, index) => (
-                <li key={index} className="flex items-center gap-2 text-sm">
-                  <div className="w-1.5 h-1.5 bg-secondary rounded-full" />
-                  {feature}
-                </li>
-              )
-            )}
+            {subscription?.subscription_plans?.features?.map((feature, index) => (
+              <li key={index} className="flex items-center gap-2 text-sm">
+                <div className="w-1.5 h-1.5 bg-secondary rounded-full" />
+                {feature}
+              </li>
+            ))}
             <li className="flex items-center gap-2 text-sm">
               <div className="w-1.5 h-1.5 bg-secondary rounded-full" />
               {isOnFreePlan ? "Up to 100 applications" : "Unlimited applications"}
@@ -207,7 +207,7 @@ export function SubscriptionManagement({
               <Link href="/dashboard/upgrade" className="flex-1">
                 <Button
                   variant="outline"
-                  className="w-full bg-green-50 border-green-200 text-green-700 hover:bg-green-100"
+                  className={`w-full ${isAuditEnabled ? "bg-secondary/10 border-secondary/20 text-secondary hover:bg-secondary/15" : "bg-green-50 border-green-200 text-green-700 hover:bg-green-100"}`}
                 >
                   <Crown className="h-4 w-4 mr-2" />
                   Reactivate Subscription
@@ -218,7 +218,7 @@ export function SubscriptionManagement({
                 variant="outline"
                 onClick={() => setConfirmCancelOpen(true)}
                 disabled={loadingCancel}
-                className="flex-1 text-red-600 border-red-200 hover:bg-red-50"
+                className={`flex-1 ${isAuditEnabled ? "text-destructive border-destructive/20 hover:bg-destructive/10" : "text-red-600 border-red-200 hover:bg-red-50"}`}
               >
                 {loadingCancel ? (
                   <>
@@ -243,7 +243,7 @@ export function SubscriptionManagement({
         subscription.status !== "canceled" &&
         (subscription.status === "active" ||
           subscription.status === "trialing") && (
-          <div className="p-3 text-sm text-yellow-700 bg-yellow-50 border border-yellow-200 rounded-md">
+          <div className={`p-3 text-sm rounded-md ${isAuditEnabled ? "text-warning-foreground bg-warning/10 border border-warning/20" : "text-yellow-700 bg-yellow-50 border border-yellow-200"}`}>
             Your subscription will end on{" "}
             {subscription.current_period_end
               ? formatLocalDate(subscription.current_period_end)
@@ -255,7 +255,7 @@ export function SubscriptionManagement({
 
       {subscription?.status === "canceled" &&
         subscription?.current_period_end && (
-          <div className="p-3 text-sm text-orange-600 bg-orange-50 border border-orange-200 rounded-md">
+          <div className={`p-3 text-sm rounded-md ${isAuditEnabled ? "text-warning-foreground bg-warning/10 border border-warning/20" : "text-orange-600 bg-orange-50 border border-orange-200"}`}>
             Your subscription is canceled and will end on{" "}
             {formatLocalDate(subscription.current_period_end)}.
             You can still upgrade to reactivate your subscription.
@@ -301,7 +301,7 @@ export function SubscriptionManagement({
               variant="outline"
               onClick={handleCancelSubscription}
               disabled={loadingCancel}
-              className="border-red-200 text-red-600 hover:bg-red-600 hover:text-white"
+              className={isAuditEnabled ? "border-destructive/20 text-destructive hover:bg-destructive hover:text-destructive-foreground" : "border-red-200 text-red-600 hover:bg-red-600 hover:text-white"}
             >
               {loadingCancel ? "Canceling..." : "Yes, Cancel Subscription"}
             </Button>

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -10,7 +10,7 @@ const badgeVariants = cva(
       variant: {
         default:
           "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
-        secondary: "border-secondary bg-transparent text-secondary-foreground",
+        secondary: "border-transparent bg-secondary text-secondary-foreground",
         destructive:
           "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
         outline: "text-foreground border-input",

--- a/lib/analytics/posthog-server.ts
+++ b/lib/analytics/posthog-server.ts
@@ -20,6 +20,33 @@ function getClient(): PostHog | null {
  * Returns a Promise — wrap in after() in route handlers so Vercel
  * keeps the lambda alive until the HTTP request to PostHog completes.
  */
+/**
+ * Evaluate a feature flag server-side for a given user.
+ * Returns the flag value (boolean or string variant), or the fallback if
+ * PostHog is unavailable. This avoids client-side flash of content.
+ */
+export async function getServerFeatureFlag(
+  distinctId: string,
+  flagName: string,
+  fallback: boolean = false
+): Promise<boolean> {
+  // Dev override: NEXT_PUBLIC_FF_<FLAG_NAME>=true in .env
+  // e.g. NEXT_PUBLIC_FF_DASHBOARD_UX_AUDIT_V1=true
+  const envKey = `NEXT_PUBLIC_FF_${flagName.toUpperCase().replace(/-/g, "_")}`;
+  const envVal = process.env[envKey];
+  if (envVal === "true") return true;
+  if (envVal === "false") return false;
+
+  try {
+    const client = getClient();
+    if (!client) return fallback;
+    const value = await client.isFeatureEnabled(flagName, distinctId);
+    return value ?? fallback;
+  } catch {
+    return fallback;
+  }
+}
+
 export async function captureServerEvent(
   distinctId: string,
   event: string,

--- a/lib/constants/ai-theme.ts
+++ b/lib/constants/ai-theme.ts
@@ -101,10 +101,96 @@ export const AI_THEME = {
   },
 } as const;
 
+// Semantic token version — uses CSS variables that adapt to dark mode automatically
+const AI_THEME_SEMANTIC = {
+  classes: {
+    text: {
+      primary: "text-ai-brand",
+      secondary: "text-accent",
+      muted: "text-ai-brand/70",
+    },
+    background: {
+      solid: "bg-ai-brand",
+      light: "bg-ai-brand-light",
+      gradient: "bg-gradient-to-r from-amber-600 to-orange-600", // gradients can't use CSS vars
+      gradientLight: "bg-ai-brand-light",
+      gradientSubtle: "bg-ai-brand/10",
+    },
+    border: {
+      default: "border-ai-brand/20",
+      strong: "border-ai-brand",
+      subtle: "border-ai-brand/10",
+    },
+    hover: {
+      background: "hover:bg-ai-brand/90",
+      text: "hover:text-ai-brand/80",
+      subtle: "hover:bg-ai-brand-light hover:text-ai-brand",
+    },
+    focus: {
+      ring: "focus:ring-ai-brand focus:ring-offset-2",
+      border: "focus:border-ai-brand",
+    },
+    button: {
+      primary: "bg-gradient-to-r from-amber-600 to-orange-600 hover:from-amber-700 hover:to-orange-700 text-white",
+      secondary: "bg-card text-ai-brand hover:bg-ai-brand-light",
+      outline: "border-ai-brand/20 text-ai-brand hover:bg-ai-brand-light",
+    },
+    badge: {
+      default: "bg-gradient-to-r from-amber-600 to-orange-600 text-white",
+      subtle: "bg-ai-brand-light text-ai-brand",
+    },
+    card: {
+      border: "border-2 border-ai-brand/20",
+      background: "bg-ai-brand/5",
+      highlight: "ring-2 ring-ai-brand ring-opacity-50",
+    },
+    iconContainer: {
+      default: "bg-ai-brand-light text-ai-brand",
+      gradient: "bg-gradient-to-br from-amber-600 to-orange-600 text-white",
+      bordered: "border border-ai-brand/20",
+    },
+  },
+} as const;
+
+/**
+ * Returns AI theme classes based on whether semantic tokens should be used.
+ * When useSemanticTokens is true, returns CSS variable-based classes that
+ * automatically adapt to dark mode without manual dark: prefixes.
+ */
+export function getAIThemeClasses(useSemanticTokens: boolean) {
+  if (useSemanticTokens) {
+    return {
+      ...AI_THEME_SEMANTIC.classes,
+      getButtonClasses: (variant: "primary" | "secondary" | "outline" = "primary") =>
+        AI_THEME_SEMANTIC.classes.button[variant],
+      getBadgeClasses: (variant: "default" | "subtle" = "default") =>
+        AI_THEME_SEMANTIC.classes.badge[variant],
+      getCardClasses: (includeHighlight = false) => {
+        const base = `${AI_THEME_SEMANTIC.classes.card.border} ${AI_THEME_SEMANTIC.classes.card.background}`;
+        return includeHighlight ? `${base} ${AI_THEME_SEMANTIC.classes.card.highlight}` : base;
+      },
+      getIconContainerClasses: (variant: "default" | "gradient" | "bordered" = "default") => {
+        const base = AI_THEME_SEMANTIC.classes.iconContainer[variant];
+        return variant === "bordered"
+          ? `${AI_THEME_SEMANTIC.classes.iconContainer.default} ${base}`
+          : base;
+      },
+    };
+  }
+
+  return {
+    ...AI_THEME.classes,
+    getButtonClasses: AI_THEME.getButtonClasses,
+    getBadgeClasses: AI_THEME.getBadgeClasses,
+    getCardClasses: AI_THEME.getCardClasses,
+    getIconContainerClasses: AI_THEME.getIconContainerClasses,
+  };
+}
+
 // Feature-specific color mappings (for backward compatibility)
 export const AI_FEATURE_COLORS = {
   resume: "amber",
-  interview: "blue", 
+  interview: "blue",
   advice: "green",
   "cover-letter": "orange",
 } as const;

--- a/lib/constants/navigation.ts
+++ b/lib/constants/navigation.ts
@@ -5,7 +5,6 @@ import {
   Brain,
   BarChart3,
   Settings,
-  Flame,
 } from "lucide-react";
 import { PLAN_NAMES } from "./plans";
 import { PLAN_THEMES } from "./plan-themes";
@@ -37,14 +36,6 @@ export const NAV_ITEMS: readonly NavItem[] = [
     icon: Brain,
     highlight: true,
     description: "AI-powered career coaching and insights",
-  },
-  {
-    id: "resume-roast",
-    label: "Resume Roast",
-    href: "/roast-my-resume",
-    icon: Flame,
-    badge: "NEW",
-    description: "Get brutally honest AI feedback on your resume",
   },
 ];
 

--- a/lib/hooks/use-feature-flag.ts
+++ b/lib/hooks/use-feature-flag.ts
@@ -13,6 +13,9 @@ export const FEATURE_FLAGS = {
   AI_TEASER_DESIGN: "ai-teaser-design",
   REFERRAL_PROGRAM_BETA: "referral-program-beta",
   
+  // Dashboard UX audit
+  DASHBOARD_UX_AUDIT: "dashboard-ux-audit-v1",
+
   // Other feature flags
   EXIT_INTENT_POPUP: "exit-intent-popup",
   ONBOARDING_V2: "onboarding-v2",
@@ -28,12 +31,40 @@ export type FeatureFlag = typeof FEATURE_FLAGS[keyof typeof FEATURE_FLAGS];
  * @param fallback - Fallback value if PostHog is not available (default: false)
  * @returns boolean indicating if the feature is enabled
  */
+/**
+ * Dev-only: check localStorage for flag overrides.
+ * Set via browser console: localStorage.setItem("ff:dashboard-ux-audit-v1", "true")
+ * Remove override: localStorage.removeItem("ff:dashboard-ux-audit-v1")
+ */
+function getLocalOverride(flagName: string): boolean | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const val = localStorage.getItem(`ff:${flagName}`);
+    if (val === "true") return true;
+    if (val === "false") return false;
+  } catch {
+    // localStorage unavailable
+  }
+  return null;
+}
+
 export function useFeatureFlag(flagName: FeatureFlag, fallback = false): boolean {
   const posthog = usePostHog();
-  const [isEnabled, setIsEnabled] = useState(fallback);
+  const [isEnabled, setIsEnabled] = useState(() => {
+    const local = getLocalOverride(flagName);
+    return local ?? fallback;
+  });
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
+    // Dev override takes priority
+    const localOverride = getLocalOverride(flagName);
+    if (localOverride !== null) {
+      setIsEnabled(localOverride);
+      setIsLoading(false);
+      return;
+    }
+
     if (!posthog) {
       setIsLoading(false);
       return;

--- a/lib/stripe/client.ts
+++ b/lib/stripe/client.ts
@@ -1,10 +1,28 @@
 import Stripe from "stripe";
 import { STRIPE_API_VERSION } from "./config";
 
-if (!process.env.STRIPE_SECRET_KEY) {
-  throw new Error("STRIPE_SECRET_KEY is not set");
+let client: Stripe | null = null;
+
+function getStripeClient() {
+  if (client) {
+    return client;
+  }
+
+  if (!process.env.STRIPE_SECRET_KEY) {
+    throw new Error("STRIPE_SECRET_KEY is not set");
+  }
+
+  client = new Stripe(process.env.STRIPE_SECRET_KEY, {
+    apiVersion: STRIPE_API_VERSION,
+  });
+
+  return client;
 }
 
-export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: STRIPE_API_VERSION,
+export const stripe = new Proxy({} as Stripe, {
+  get(_target, prop) {
+    const client = getStripeClient();
+    const value = client[prop as keyof Stripe];
+    return typeof value === 'function' ? value.bind(client) : value;
+  }
 });

--- a/lib/supabase/browser-client.ts
+++ b/lib/supabase/browser-client.ts
@@ -1,8 +1,8 @@
 import { createBrowserClient } from "@supabase/ssr";
 
 export const supabase = createBrowserClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  process.env.NEXT_PUBLIC_SUPABASE_URL || "https://placeholder.supabase.co",
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "placeholder-key",
   {
     auth: {
       persistSession: true,

--- a/lib/supabase/browser-client.ts
+++ b/lib/supabase/browser-client.ts
@@ -1,13 +1,43 @@
 import { createBrowserClient } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
-export const supabase = createBrowserClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || "https://placeholder.supabase.co",
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "placeholder-key",
-  {
-    auth: {
-      persistSession: true,
-      detectSessionInUrl: true,
-      flowType: "pkce",
-    },
+let client: SupabaseClient | null = null;
+
+function getSupabaseClient() {
+  if (client) {
+    return client;
   }
-);
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl) {
+    throw new Error("NEXT_PUBLIC_SUPABASE_URL is not set");
+  }
+
+  if (!supabaseAnonKey) {
+    throw new Error("NEXT_PUBLIC_SUPABASE_ANON_KEY is not set");
+  }
+
+  client = createBrowserClient(
+    supabaseUrl,
+    supabaseAnonKey,
+    {
+      auth: {
+        persistSession: true,
+        detectSessionInUrl: true,
+        flowType: "pkce",
+      },
+    }
+  );
+
+  return client;
+}
+
+export const supabase = new Proxy({} as SupabaseClient, {
+  get(_target, prop) {
+    const client = getSupabaseClient();
+    const value = client[prop as keyof SupabaseClient];
+    return typeof value === 'function' ? value.bind(client) : value;
+  }
+});

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -53,6 +53,19 @@ const config = {
           DEFAULT: "hsl(var(--destructive))",
           foreground: "hsl(var(--destructive-foreground))",
         },
+        warning: {
+          DEFAULT: "hsl(var(--warning))",
+          foreground: "hsl(var(--warning-foreground))",
+        },
+        info: {
+          DEFAULT: "hsl(var(--info))",
+          foreground: "hsl(var(--info-foreground))",
+        },
+        "ai-brand": {
+          DEFAULT: "hsl(var(--ai-brand))",
+          foreground: "hsl(var(--ai-brand-foreground))",
+          light: "hsl(var(--ai-brand-light))",
+        },
         muted: {
           DEFAULT: "hsl(var(--muted))",
           foreground: "hsl(var(--muted-foreground))",


### PR DESCRIPTION
## Summary

Full UX/UI audit of the logged-in dashboard experience with fixes for layout, design system, dark mode, and mobile responsiveness.

### Feature-flagged changes (`dashboard-ux-audit-v1`)
- **Dashboard layout reorder**: Stats > Applications > Pipeline > compact AI Coach teaser (moved from above the fold to bottom)
- **Tamed upsell**: Removed banner auto-rotation/delay, removed overlay blur, extended dismiss to 30 days
- **Semantic color tokens**: Replaced 30+ hardcoded `red-600`, `green-50`, etc. with `destructive`, `warning`, `info` tokens
- **AI_THEME refactor**: Added `getAIThemeClasses()` for CSS variable-based theming
- **Pipeline chart**: Better empty/sparse states with CTA
- **Mobile header**: Application detail stacks title and actions vertically

### Direct changes (no feature flag)
- **Footer on all auth pages** via new `(app)/layout.tsx`
- **Dark mode fix**: `--primary` lightened from 65% to 75% for readability
- **Headings**: Changed from `text-primary` to `text-foreground` (removes purple/blue clash)
- **Resume Roast**: Removed from dashboard nav tabs (still in user dropdown menu)
- **Badge fix**: `secondary` variant now solid green with visible white text
- **Upgrade page**: AI Coach card first on mobile, 2-column FAQ grid, fixed Save 33% badge contrast
- **Mobile nav**: Drawer opens from right (matches hamburger position), tighter padding
- **AI Coach tabs**: 5-column grid instead of 3+2 orphan layout
- **Career advice**: Hidden sidebar on mobile (prevents horizontal overflow)

### Infrastructure
- New design tokens: `--warning`, `--info`, `--ai-brand` (CSS vars + Tailwind config)
- Server-side feature flag evaluation (`getServerFeatureFlag`) to avoid layout flash
- `DashboardFlagsProvider` React context for child components
- Dev flag overrides via `NEXT_PUBLIC_FF_DASHBOARD_UX_AUDIT_V1=true` env var

## Test plan
- [ ] Flag OFF: All dashboard pages render identically to production
- [ ] Flag ON: Dashboard shows apps above AI coach, compact teaser at bottom
- [ ] Light mode: Headings are dark, no purple clash with blue buttons
- [ ] Dark mode: All text readable, `--primary` at 75% lightness, Danger Zone uses semantic tokens
- [ ] Mobile: Nav drawer from right, AI Coach tabs in single row, no horizontal overflow on advice tab
- [ ] Upgrade page: AI Coach first on mobile, FAQ in 2-column grid, badges visible
- [ ] Footer visible on all authenticated pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggleable dashboard UX via a server+client feature flag with a new dashboard layout wrapper and a reusable Danger Zone card.

* **Style & Visual Updates**
  * New semantic color tokens (warning, info, AI brand) and theme-aware header, badge, button, empty-state, ordering, and compact teaser adjustments for improved responsiveness and visual consistency.

* **Removed**
  * "Resume Roast" navigation entry and its associated “new” tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->