### PR TITLE
fix: prevent trial onboarding card from flashing back after dismissal

### DIFF
--- a/__tests__/hooks/use-trial-budget.test.ts
+++ b/__tests__/hooks/use-trial-budget.test.ts
@@ -168,6 +168,32 @@ describe('useTrialBudget', () => {
     expect(result.current.budget.onboarding_completed).toBe(false);
   });
 
+  it('refresh does not downgrade onboarding_completed from true to false', async () => {
+    // Initial fetch returns onboarding not yet completed
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ ...budgetResponse, onboarding_completed: false }),
+    });
+
+    const { result } = renderHook(() => useTrialBudget());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // User clicks "Got it" — POST succeeds, local state becomes true
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) });
+    await act(async () => { await result.current.completeOnboarding(); });
+    expect(result.current.budget.onboarding_completed).toBe(true);
+
+    // Polling refresh fires — server still returns false (race condition / slow write)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ ...budgetResponse, onboarding_completed: false }),
+    });
+    await act(async () => { await result.current.refresh(); });
+
+    // Fix: local true must survive the poll — no flash back to onboarding
+    expect(result.current.budget.onboarding_completed).toBe(true);
+  });
+
   it('completeOnboarding silently fails on error', async () => {
     // Initial fetch
     mockFetch.mockResolvedValueOnce({

--- a/hooks/use-trial-budget.ts
+++ b/hooks/use-trial-budget.ts
@@ -38,7 +38,13 @@ export function useTrialBudget() {
       if (res.ok) {
         const data: unknown = await res.json();
         if (isTrialBudgetState(data)) {
-          setBudget(data);
+          // Never downgrade onboarding_completed from true→false — the user
+          // may have dismissed the modal before the server write committed,
+          // and the polling refresh would otherwise flash it back.
+          setBudget((prev) => ({
+            ...data,
+            onboarding_completed: prev.onboarding_completed || data.onboarding_completed,
+          }));
         }
       }
     } catch {


### PR DESCRIPTION
## Summary

- **Missing migration**: `027_trial_budget_system.sql` had never been run against the DB — `ai_trial_onboarding_completed` and `ai_analyses_used` columns were absent from `profiles`. Every `GET /api/ai-coach/trial-budget` hit the error branch and returned `onboarding_completed: false`; every `POST` (completeOnboarding) silently failed. The card reappeared on every page load.
- **Polling race condition**: Even with the columns present, the 5-second poll in `useTrialBudget.refresh()` called `setBudget(serverData)` directly, overwriting the locally-set `true` with `false` if the GET response arrived before the POST write committed to the DB.

## Changes

- Ran `schemas/migrations/027_trial_budget_system.sql` against the database to add the missing columns and SQL functions
- Updated `refresh()` in `hooks/use-trial-budget.ts` to use a functional `setState` that preserves `onboarding_completed: true` once set — the server can never downgrade it back to `false` within the same session
- Added a regression test that simulates the exact race condition: completeOnboarding succeeds locally, then a poll returns `false` from the server — verifies the local `true` survives

## Test plan

- [x] Verified end-to-end in browser: clicked "Got it", waited 12s (2+ poll cycles), card did not reappear
- [x] All existing `use-trial-budget` tests pass
- [x] New race condition regression test passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where onboarding completion status would revert after refreshing account data, ensuring the completed status persists locally.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jlamoreaux/apptrack/pull/172)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->