### PR TITLE
fix: AI Coach chat Retry crash + in-app support form + error boundaries

### DIFF
--- a/__tests__/api/support.test.ts
+++ b/__tests__/api/support.test.ts
@@ -236,6 +236,27 @@ describe("POST /api/support", () => {
     expect(data.success).toBe(true);
   });
 
+  it("fails closed with 500 when the email is mocked in production", async () => {
+    mockSendEmail.mockResolvedValue({ success: true, mock: true } as any);
+    // NODE_ENV is typed read-only; assign through a widened view of process.env.
+    const env = process.env as Record<string, string | undefined>;
+    const originalEnv = env.NODE_ENV;
+    // NODE_ENV is read inside the handler; force production for this case so a
+    // missing RESEND_API_KEY surfaces as an error instead of a silent drop.
+    env.NODE_ENV = "production";
+
+    try {
+      const POST = loadPost();
+      const response = await POST(createRequest(validBody));
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.success).toBe(false);
+    } finally {
+      env.NODE_ENV = originalEnv;
+    }
+  });
+
   it("returns 500 without leaking provider internals when send fails", async () => {
     mockSendEmail.mockRejectedValue(new Error("Resend internal: API key 12345"));
     const POST = loadPost();

--- a/__tests__/api/support.test.ts
+++ b/__tests__/api/support.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Tests for POST /api/support
+ * Covers auth, body validation, rate limiting, HTML escaping, and send behavior.
+ */
+
+import { createClient } from "@/lib/supabase/server";
+import { sendEmail } from "@/lib/email/client";
+import { SUPPORT_EMAIL } from "@/lib/constants/site-config";
+
+jest.mock("@/lib/supabase/server");
+jest.mock("@/lib/email/client", () => ({
+  sendEmail: jest.fn(),
+}));
+jest.mock("@/lib/services/logger.service", () => ({
+  loggerService: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const mockCreateClient = createClient as jest.MockedFunction<
+  typeof createClient
+>;
+const mockSendEmail = sendEmail as jest.MockedFunction<typeof sendEmail>;
+
+const mockUser = { id: "user123", email: "test@example.com" };
+
+function setAuthedUser(user: { id: string; email?: string } | null) {
+  mockCreateClient.mockResolvedValue({
+    auth: {
+      getUser: jest.fn().mockResolvedValue({
+        data: { user },
+        error: null,
+      }),
+    },
+  } as any);
+}
+
+function createRequest(body: unknown) {
+  // A string body is returned verbatim by the mock Request, so passing an
+  // invalid-JSON string lets us exercise the malformed-JSON path.
+  return new (global as any).NextRequest("http://localhost:3000/api/support", {
+    method: "POST",
+    body,
+  });
+}
+
+const validBody = {
+  category: "Bug / something broke",
+  subject: "Something broke",
+  message: "Here is what happened.",
+  context: { url: "https://app.example.com/dashboard" },
+};
+
+// Import POST fresh so the route's in-module rate-limit map starts empty.
+function loadPost() {
+  let post!: typeof import("@/app/api/support/route").POST;
+  jest.isolateModules(() => {
+    post = require("@/app/api/support/route").POST;
+  });
+  return post;
+}
+
+describe("POST /api/support", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSendEmail.mockResolvedValue({ success: true } as any);
+    setAuthedUser(mockUser);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    setAuthedUser(null);
+    const POST = loadPost();
+
+    const response = await POST(createRequest(validBody));
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on malformed JSON", async () => {
+    const POST = loadPost();
+
+    const response = await POST(createRequest("{ not valid json"));
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBeDefined();
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when subject is missing", async () => {
+    const POST = loadPost();
+
+    const response = await POST(
+      createRequest({ ...validBody, subject: undefined })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when message is empty", async () => {
+    const POST = loadPost();
+
+    const response = await POST(
+      createRequest({ ...validBody, message: "   " })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when subject is over length", async () => {
+    const POST = loadPost();
+
+    const response = await POST(
+      createRequest({ ...validBody, subject: "a".repeat(201) })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when message is over length", async () => {
+    const POST = loadPost();
+
+    const response = await POST(
+      createRequest({ ...validBody, message: "a".repeat(5001) })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a category not in the allowlist", async () => {
+    const POST = loadPost();
+
+    const response = await POST(
+      createRequest({ ...validBody, category: "Hacking" })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when context URL is too long", async () => {
+    const POST = loadPost();
+
+    const response = await POST(
+      createRequest({
+        ...validBody,
+        context: { url: `https://x.com/${"a".repeat(2001)}` },
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 when the per-user rate limit is exceeded", async () => {
+    const POST = loadPost();
+
+    // 5 allowed within the window, the 6th is rejected.
+    for (let i = 0; i < 5; i++) {
+      const ok = await POST(createRequest(validBody));
+      expect(ok.status).toBe(200);
+    }
+
+    const limited = await POST(createRequest(validBody));
+    const data = await limited.json();
+
+    expect(limited.status).toBe(429);
+    expect(data.error).toBeDefined();
+    expect(mockSendEmail).toHaveBeenCalledTimes(5);
+  });
+
+  it("returns 200 and sends to SUPPORT_EMAIL with reply-to = user email", async () => {
+    const POST = loadPost();
+
+    const response = await POST(createRequest(validBody));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+
+    const args = mockSendEmail.mock.calls[0][0];
+    expect(args.to).toBe(SUPPORT_EMAIL);
+    expect(args.replyTo).toBe(mockUser.email);
+    expect(args.subject).toBe(
+      "[Support] [Bug / something broke] Something broke"
+    );
+  });
+
+  it("omits reply-to when the user has no email", async () => {
+    setAuthedUser({ id: "user-no-email" });
+    const POST = loadPost();
+
+    const response = await POST(createRequest(validBody));
+
+    expect(response.status).toBe(200);
+    const args = mockSendEmail.mock.calls[0][0];
+    expect(args.replyTo).toBeUndefined();
+    expect(args.html).toContain("No reply address on file");
+  });
+
+  it("escapes user-supplied HTML in the email body", async () => {
+    const POST = loadPost();
+
+    await POST(
+      createRequest({
+        ...validBody,
+        subject: "<script>alert(1)</script>",
+        message: "<img src=x onerror=alert(1)>",
+      })
+    );
+
+    const args = mockSendEmail.mock.calls[0][0];
+    expect(args.html).not.toContain("<script>alert(1)</script>");
+    expect(args.html).toContain("&lt;script&gt;");
+    expect(args.html).toContain("&lt;img");
+  });
+
+  it("returns success even when the email is mocked (no RESEND_API_KEY)", async () => {
+    mockSendEmail.mockResolvedValue({ success: true, mock: true } as any);
+    const POST = loadPost();
+
+    const response = await POST(createRequest(validBody));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+  });
+
+  it("returns 500 without leaking provider internals when send fails", async () => {
+    mockSendEmail.mockRejectedValue(new Error("Resend internal: API key 12345"));
+    const POST = loadPost();
+
+    const response = await POST(createRequest(validBody));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe("Failed to send support request.");
+    expect(JSON.stringify(data)).not.toContain("12345");
+  });
+});

--- a/__tests__/components/career-advice-retry.test.tsx
+++ b/__tests__/components/career-advice-retry.test.tsx
@@ -1,10 +1,10 @@
 /**
- * Tests for the AI Coach chat "Retry" button (crash-fix regression guard).
+ * Behavior contract for the AI Coach chat "Retry" button (career-advice.tsx).
  *
- * The bug: career-advice.tsx destructured `reload` from useChat, but ai@6 /
- * @ai-sdk/react@3 renamed it to `regenerate`, so clicking Retry threw
- * "reload is not a function". These tests mock useChat in the error state and
- * assert Retry re-fires the request via `regenerate` and clears the error.
+ * In the chat error state, clicking "Retry" must re-fire the request via
+ * useChat's `regenerate`, clear the error via `clearError`, and emit the
+ * ai_chat_retry_clicked analytics event — without falling back to manual
+ * sendMessage. These tests mock useChat in the error state and assert that.
  */
 
 import React from "react";
@@ -61,15 +61,21 @@ jest.mock("lucide-react", () => {
 import { CareerAdvice } from "@/components/ai-coach/career-advice";
 
 describe("CareerAdvice retry button", () => {
+  let fetchSpy: jest.SpyInstance;
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockRegenerate.mockResolvedValue(undefined);
     // The component fetches conversations on mount; return an empty list.
-    (global.fetch as jest.Mock).mockResolvedValue({
+    fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue({
       ok: true,
       json: async () => ({ conversations: [] }),
       headers: { get: () => null },
-    });
+    } as unknown as Response);
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
   });
 
   it("renders a Retry button in the error state", async () => {

--- a/__tests__/components/career-advice-retry.test.tsx
+++ b/__tests__/components/career-advice-retry.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * Tests for the AI Coach chat "Retry" button (crash-fix regression guard).
+ *
+ * The bug: career-advice.tsx destructured `reload` from useChat, but ai@6 /
+ * @ai-sdk/react@3 renamed it to `regenerate`, so clicking Retry threw
+ * "reload is not a function". These tests mock useChat in the error state and
+ * assert Retry re-fires the request via `regenerate` and clears the error.
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const mockRegenerate = jest.fn();
+const mockClearError = jest.fn();
+const mockSendMessage = jest.fn();
+const mockStop = jest.fn();
+const mockSetMessages = jest.fn();
+
+const mockUseChatState = {
+  messages: [
+    {
+      id: "user-1",
+      role: "user" as const,
+      parts: [{ type: "text" as const, text: "Help me with my resume" }],
+    },
+  ],
+  sendMessage: mockSendMessage,
+  setMessages: mockSetMessages,
+  status: "error" as const,
+  error: new Error("Something went wrong"),
+  regenerate: mockRegenerate,
+  clearError: mockClearError,
+  stop: mockStop,
+};
+
+jest.mock("@ai-sdk/react", () => ({
+  useChat: () => mockUseChatState,
+}));
+
+jest.mock("ai", () => ({
+  DefaultChatTransport: jest.fn().mockImplementation(() => ({})),
+}));
+
+// react-markdown is ESM-only; render its children as plain text for tests.
+jest.mock("react-markdown", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const mockCapturePostHogEvent = jest.fn();
+jest.mock("@/lib/analytics/posthog", () => ({
+  capturePostHogEvent: (...args: unknown[]) => mockCapturePostHogEvent(...args),
+}));
+
+// career-advice.tsx uses icons not covered by the global jest.setup mock.
+jest.mock("lucide-react", () => {
+  const Icon = () => <span data-testid="icon" />;
+  return new Proxy({}, { get: () => Icon });
+});
+
+import { CareerAdvice } from "@/components/ai-coach/career-advice";
+
+describe("CareerAdvice retry button", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRegenerate.mockResolvedValue(undefined);
+    // The component fetches conversations on mount; return an empty list.
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ conversations: [] }),
+      headers: { get: () => null },
+    });
+  });
+
+  it("renders a Retry button in the error state", async () => {
+    render(<CareerAdvice />);
+    expect(await screen.findByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("clears the error and re-fires the request via regenerate when Retry is clicked", async () => {
+    render(<CareerAdvice />);
+
+    const retryButton = await screen.findByRole("button", { name: /retry/i });
+    fireEvent.click(retryButton);
+
+    await waitFor(() => {
+      expect(mockClearError).toHaveBeenCalledTimes(1);
+      expect(mockRegenerate).toHaveBeenCalledTimes(1);
+    });
+    // Re-fire goes through the SDK, not the manual sendMessage path.
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it("captures a success analytics event when the re-fire resolves", async () => {
+    render(<CareerAdvice />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /retry/i }));
+
+    await waitFor(() => {
+      expect(mockCapturePostHogEvent).toHaveBeenCalledWith("ai_chat_retry_clicked", {
+        outcome: "success",
+      });
+    });
+  });
+
+  it("captures a failure analytics event when the re-fire rejects", async () => {
+    mockRegenerate.mockRejectedValueOnce(new Error("retry failed"));
+    render(<CareerAdvice />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /retry/i }));
+
+    await waitFor(() => {
+      expect(mockCapturePostHogEvent).toHaveBeenCalledWith("ai_chat_retry_clicked", {
+        outcome: "failure",
+      });
+    });
+  });
+});

--- a/__tests__/components/error-boundary-support.test.tsx
+++ b/__tests__/components/error-boundary-support.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * Tests for the shared error-boundary fallback (SupportErrorFallback) rendered
+ * via SectionErrorBoundary. Verifies the friendly UI, the support link, the
+ * recovery action, and that the boundary-triggered analytics event fires once.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { SectionErrorBoundary } from "@/components/accessibility/error-boundary";
+import { SupportErrorFallback } from "@/components/support/support-error-fallback";
+
+const mockCapture = jest.fn();
+jest.mock("@/lib/analytics/posthog", () => ({
+  capturePostHogEvent: (...args: unknown[]) => mockCapture(...args),
+}));
+
+function Boom(): never {
+  throw new Error("kaboom");
+}
+
+describe("SupportErrorFallback via SectionErrorBoundary", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockCapture.mockClear();
+    // React logs caught render errors to console.error; silence the expected noise.
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("renders the fallback when a child throws", () => {
+    render(
+      <SectionErrorBoundary
+        name="Test"
+        fallback={<SupportErrorFallback name="Test" />}
+      >
+        <Boom />
+      </SectionErrorBoundary>
+    );
+
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("shows a Contact support link pointing at /dashboard/support", () => {
+    render(
+      <SectionErrorBoundary
+        name="Test"
+        fallback={<SupportErrorFallback name="Test" />}
+      >
+        <Boom />
+      </SectionErrorBoundary>
+    );
+
+    const supportLink = screen.getByRole("link", { name: /contact support/i });
+    expect(supportLink).toHaveAttribute("href", "/dashboard/support");
+  });
+
+  it("renders a recovery (try again) button", () => {
+    render(
+      <SectionErrorBoundary
+        name="Test"
+        fallback={<SupportErrorFallback name="Test" />}
+      >
+        <Boom />
+      </SectionErrorBoundary>
+    );
+
+    expect(
+      screen.getByRole("button", { name: /try again/i })
+    ).toBeInTheDocument();
+  });
+
+  it("fires the error_boundary_triggered analytics event once", () => {
+    render(
+      <SectionErrorBoundary
+        name="Test"
+        fallback={<SupportErrorFallback name="Test" />}
+      >
+        <Boom />
+      </SectionErrorBoundary>
+    );
+
+    const triggeredCalls = mockCapture.mock.calls.filter(
+      ([eventName]) => eventName === "error_boundary_triggered"
+    );
+    expect(triggeredCalls).toHaveLength(1);
+    expect(triggeredCalls[0][1]).toEqual(
+      expect.objectContaining({ boundary: "Test" })
+    );
+  });
+});

--- a/__tests__/components/support-form.test.tsx
+++ b/__tests__/components/support-form.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * Tests for SupportForm component
+ */
+
+import type { ReactNode } from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { SupportForm } from "@/components/support/support-form";
+import { SUPPORT_CATEGORIES } from "@/lib/constants/site-config";
+
+// The shared Select wraps Radix + lucide icons that aren't all mocked in the
+// global jest setup; render a lightweight native equivalent so the form itself
+// is what's under test.
+jest.mock("@/components/ui/select", () => {
+  const Passthrough = ({ children }: { children?: ReactNode }) => (
+    <>{children}</>
+  );
+  return {
+    Select: ({ children }: { children?: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    SelectTrigger: Passthrough,
+    SelectValue: Passthrough,
+    SelectContent: Passthrough,
+    SelectItem: ({ children }: { children?: ReactNode }) => (
+      <div>{children}</div>
+    ),
+  };
+});
+
+const mockToast = jest.fn();
+jest.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+const mockCapture = jest.fn();
+jest.mock("@/lib/analytics/posthog", () => ({
+  capturePostHogEvent: (...args: unknown[]) => mockCapture(...args),
+}));
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+function getSubjectInput() {
+  return screen.getByLabelText("Subject") as HTMLInputElement;
+}
+
+function getMessageInput() {
+  return screen.getByLabelText("Message") as HTMLTextAreaElement;
+}
+
+function getSubmitButton() {
+  return screen.getByRole("button", { name: /send message/i });
+}
+
+function fillValidForm() {
+  fireEvent.change(getSubjectInput(), { target: { value: "Cannot retry" } });
+  fireEvent.change(getMessageInput(), {
+    target: { value: "The retry button does nothing." },
+  });
+}
+
+describe("SupportForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("disables submit when subject and message are empty", () => {
+    render(<SupportForm source="page" />);
+    expect(getSubmitButton()).toBeDisabled();
+  });
+
+  it("disables submit when subject is over the length cap", () => {
+    render(<SupportForm source="page" />);
+    fireEvent.change(getMessageInput(), { target: { value: "valid message" } });
+    fireEvent.change(getSubjectInput(), {
+      target: { value: "x".repeat(201) },
+    });
+    expect(getSubmitButton()).toBeDisabled();
+  });
+
+  it("disables submit when message is over the length cap", () => {
+    render(<SupportForm source="page" />);
+    fireEvent.change(getSubjectInput(), { target: { value: "valid subject" } });
+    fireEvent.change(getMessageInput(), {
+      target: { value: "x".repeat(5001) },
+    });
+    expect(getSubmitButton()).toBeDisabled();
+  });
+
+  it("enables submit when subject and message are valid", () => {
+    render(<SupportForm source="page" />);
+    fillValidForm();
+    expect(getSubmitButton()).toBeEnabled();
+  });
+
+  it("fires support_form_opened once on mount with the source", () => {
+    render(<SupportForm source="nav" />);
+    expect(mockCapture).toHaveBeenCalledWith("support_form_opened", {
+      source: "nav",
+    });
+  });
+
+  it("POSTs the expected payload and calls onDone on success", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true }),
+    });
+    const onDone = jest.fn();
+
+    render(
+      <SupportForm
+        source="error_fallback"
+        initialContext={{ errorMessage: "boom" }}
+        onDone={onDone}
+      />
+    );
+    fillValidForm();
+    fireEvent.click(getSubmitButton());
+
+    await waitFor(() => {
+      expect(onDone).toHaveBeenCalled();
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/support",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          category: SUPPORT_CATEGORIES[0],
+          subject: "Cannot retry",
+          message: "The retry button does nothing.",
+          context: {
+            url: window.location.href,
+            errorMessage: "boom",
+          },
+        }),
+      })
+    );
+    expect(mockCapture).toHaveBeenCalledWith("support_request_submitted", {
+      category: SUPPORT_CATEGORIES[0],
+    });
+  });
+
+  it("disables the submit button during an in-flight submit", async () => {
+    let resolveFetch: ((value: unknown) => void) | undefined;
+    mockFetch.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+
+    render(<SupportForm source="page" />);
+    fillValidForm();
+    fireEvent.click(getSubmitButton());
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /sending/i })
+      ).toBeDisabled();
+    });
+
+    resolveFetch?.({ ok: true, status: 200, json: async () => ({}) });
+    await waitFor(() => {
+      expect(screen.getByText(/your message was sent/i)).toBeInTheDocument();
+    });
+  });
+
+  it("renders the success state after a successful submit", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true }),
+    });
+
+    render(<SupportForm source="page" />);
+    fillValidForm();
+    fireEvent.click(getSubmitButton());
+
+    await waitFor(() => {
+      expect(screen.getByText(/your message was sent/i)).toBeInTheDocument();
+    });
+  });
+
+  it("renders an inline error and reports failure on a non-2xx response", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      json: async () => ({ error: "Too many requests" }),
+    });
+
+    render(<SupportForm source="page" />);
+    fillValidForm();
+    fireEvent.click(getSubmitButton());
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/went wrong/i);
+    });
+    expect(mockCapture).toHaveBeenCalledWith("support_request_failed", {
+      reason: "http_429",
+    });
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: "destructive" })
+    );
+  });
+
+  it("renders an inline error and reports failure on a network error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("offline"));
+
+    render(<SupportForm source="page" />);
+    fillValidForm();
+    fireEvent.click(getSubmitButton());
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+    expect(mockCapture).toHaveBeenCalledWith("support_request_failed", {
+      reason: "network_error",
+    });
+  });
+});

--- a/__tests__/components/user-menu-support.test.tsx
+++ b/__tests__/components/user-menu-support.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Tests for the "Help / Contact support" nav entry wiring in UserMenu.
+ *
+ * The Radix DropdownMenu portals its content, which is unreliable under jsdom,
+ * so the menu primitives are mocked to render children inline. SupportDialog is
+ * mocked to surface its controlled `open` prop, letting us assert that
+ * activating the menu item flips the dialog open.
+ */
+
+import type { ReactNode } from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { UserMenu } from "@/components/user-menu";
+import type { User as SupabaseUser } from "@supabase/supabase-js";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), refresh: jest.fn() }),
+}));
+
+jest.mock("@/lib/actions", () => ({
+  signOut: jest.fn(),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}));
+
+// The global setup mocks only a fixed allowlist of lucide icons; UserMenu uses
+// others (User, Settings, LifeBuoy, ...). Stub any requested icon.
+jest.mock("lucide-react", () =>
+  new Proxy(
+    {},
+    {
+      get: () => () => <span data-testid="icon" />,
+    }
+  )
+);
+
+// Render dropdown primitives inline so the support item is queryable and its
+// onSelect handler fires on click without a portal.
+jest.mock("@/components/ui/dropdown-menu", () => {
+  const Passthrough = ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  );
+  return {
+    DropdownMenu: Passthrough,
+    DropdownMenuTrigger: Passthrough,
+    DropdownMenuContent: Passthrough,
+    DropdownMenuSeparator: () => <hr />,
+    DropdownMenuItem: ({
+      children,
+      onSelect,
+      onClick,
+    }: {
+      children?: ReactNode;
+      onSelect?: (event: { preventDefault: () => void }) => void;
+      onClick?: () => void;
+    }) => (
+      <button
+        type="button"
+        onClick={() => {
+          onSelect?.({ preventDefault: () => {} });
+          onClick?.();
+        }}
+      >
+        {children}
+      </button>
+    ),
+  };
+});
+
+const supportDialogOpenStates: boolean[] = [];
+jest.mock("@/components/support/support-dialog", () => ({
+  SupportDialog: ({ open }: { open?: boolean }) => {
+    supportDialogOpenStates.push(Boolean(open));
+    return open ? <div role="dialog">Contact support</div> : null;
+  },
+}));
+
+const baseUser = { email: "user@example.com" } as SupabaseUser;
+
+beforeEach(() => {
+  supportDialogOpenStates.length = 0;
+});
+
+describe("UserMenu support entry", () => {
+  it("renders the Help / Contact support entry", () => {
+    render(
+      <UserMenu user={baseUser} profile={null} isOnFreePlan={false} />
+    );
+
+    expect(
+      screen.getByText("Help / Contact support")
+    ).toBeInTheDocument();
+  });
+
+  it("opens the support dialog when the entry is activated", () => {
+    render(
+      <UserMenu user={baseUser} profile={null} isOnFreePlan={false} />
+    );
+
+    // Dialog starts closed.
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Help / Contact support"));
+
+    expect(screen.getByRole("dialog")).toHaveTextContent("Contact support");
+    expect(supportDialogOpenStates).toContain(true);
+  });
+});

--- a/__tests__/email/support-helpers.test.ts
+++ b/__tests__/email/support-helpers.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for the in-app support email foundation:
+ * - escapeHtml / safeUrl helpers exported from lib/email/transactional
+ * - sendEmail's replyTo forwarding in lib/email/client
+ */
+
+// @jest-environment node
+
+import { escapeHtml, safeUrl } from '@/lib/email/transactional';
+
+describe('escapeHtml', () => {
+  it('escapes all five special HTML characters', () => {
+    expect(escapeHtml('&')).toBe('&amp;');
+    expect(escapeHtml('<')).toBe('&lt;');
+    expect(escapeHtml('>')).toBe('&gt;');
+    expect(escapeHtml('"')).toBe('&quot;');
+    expect(escapeHtml("'")).toBe('&#39;');
+  });
+
+  it('escapes a mixed string in a single pass', () => {
+    expect(escapeHtml('<a href="x">Tom & Jerry\'s</a>')).toBe(
+      '&lt;a href=&quot;x&quot;&gt;Tom &amp; Jerry&#39;s&lt;/a&gt;'
+    );
+  });
+
+  it('leaves plain text untouched', () => {
+    expect(escapeHtml('hello world')).toBe('hello world');
+  });
+});
+
+describe('safeUrl', () => {
+  it('returns the URL unchanged for https', () => {
+    expect(safeUrl('https://www.apptrack.ing/support')).toBe(
+      'https://www.apptrack.ing/support'
+    );
+  });
+
+  it('returns the URL unchanged for http', () => {
+    expect(safeUrl('http://example.com')).toBe('http://example.com');
+  });
+
+  it('returns "#" for the javascript: scheme', () => {
+    expect(safeUrl('javascript:alert(1)')).toBe('#');
+  });
+
+  it('returns "#" for an invalid URL', () => {
+    expect(safeUrl('not a url')).toBe('#');
+  });
+});
+
+describe('sendEmail replyTo forwarding', () => {
+  const mockSend = jest.fn();
+
+  // Mock the Resend constructor so client.ts builds a non-null `resend` client.
+  jest.mock('resend', () => ({
+    Resend: jest.fn().mockImplementation(() => ({
+      emails: { send: mockSend },
+    })),
+  }));
+
+  const ORIGINAL_API_KEY = process.env.RESEND_API_KEY;
+
+  beforeAll(() => {
+    process.env.RESEND_API_KEY = 'test-api-key';
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_API_KEY === undefined) {
+      delete process.env.RESEND_API_KEY;
+    } else {
+      process.env.RESEND_API_KEY = ORIGINAL_API_KEY;
+    }
+  });
+
+  beforeEach(() => {
+    mockSend.mockReset();
+    mockSend.mockResolvedValue({ data: { id: 'email-123' }, error: null });
+  });
+
+  /** Re-import sendEmail in isolation so the mocked Resend is applied at module load. */
+  function loadSendEmail() {
+    let send: typeof import('@/lib/email/client').sendEmail;
+    jest.isolateModules(() => {
+      send = require('@/lib/email/client').sendEmail;
+    });
+    return send!;
+  }
+
+  it('forwards replyTo to the Resend client when provided', async () => {
+    const sendEmail = loadSendEmail();
+
+    await sendEmail({
+      to: 'user@example.com',
+      subject: 'Support reply',
+      html: '<p>Hi</p>',
+      replyTo: 'support@apptrack.ing',
+    });
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    expect(mockSend.mock.calls[0][0]).toMatchObject({
+      replyTo: 'support@apptrack.ing',
+    });
+  });
+
+  it('omits replyTo from the payload when not provided', async () => {
+    const sendEmail = loadSendEmail();
+
+    await sendEmail({
+      to: 'user@example.com',
+      subject: 'No reply-to',
+      html: '<p>Hi</p>',
+    });
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    expect(mockSend.mock.calls[0][0]).not.toHaveProperty('replyTo');
+  });
+});

--- a/app/(app)/dashboard/support/page.tsx
+++ b/app/(app)/dashboard/support/page.tsx
@@ -1,0 +1,49 @@
+export const dynamic = "force-dynamic";
+import { redirect } from "next/navigation";
+import { NavigationServer } from "@/components/navigation-server";
+import { getUser } from "@/lib/supabase/server";
+import { SupportForm } from "@/components/support/support-form";
+
+interface SupportPageProps {
+  // Next 15 App Router passes searchParams as a Promise.
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+function firstParamValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+export default async function SupportPage({ searchParams }: SupportPageProps) {
+  const user = await getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const params = await searchParams;
+  const errorMessage = firstParamValue(params.errorMessage);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <NavigationServer />
+      <div className="container mx-auto px-4 py-6 sm:py-8">
+        <div className="max-w-2xl mx-auto space-y-8">
+          <div className="space-y-2">
+            <h1 className="text-2xl sm:text-3xl font-bold text-foreground">
+              Contact support
+            </h1>
+            <p className="text-muted-foreground">
+              Describe your issue and we'll reply to your account email.
+            </p>
+          </div>
+
+          <SupportForm
+            source="page"
+            initialContext={errorMessage ? { errorMessage } : undefined}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/error.tsx
+++ b/app/(app)/error.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { SupportErrorFallback } from "@/components/support/support-error-fallback";
+
+interface AppSegmentErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function AppSegmentError({ error, reset }: AppSegmentErrorProps) {
+  return (
+    <div className="container mx-auto px-4 py-16">
+      <div className="max-w-2xl mx-auto">
+        <SupportErrorFallback name="this page" error={error} reset={reset} />
+      </div>
+    </div>
+  );
+}

--- a/app/api/support/route.ts
+++ b/app/api/support/route.ts
@@ -1,0 +1,284 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { sendEmail } from "@/lib/email/client";
+import { escapeHtml, safeUrl } from "@/lib/email/transactional";
+import {
+  SUPPORT_EMAIL,
+  SUPPORT_CATEGORIES,
+  type SupportCategory,
+} from "@/lib/constants/site-config";
+import { loggerService } from "@/lib/services/logger.service";
+import { LogCategory } from "@/lib/services/logger.types";
+
+// Validation caps (named to avoid magic numbers).
+const SUBJECT_MIN = 1;
+const SUBJECT_MAX = 200;
+const MESSAGE_MIN = 1;
+const MESSAGE_MAX = 5000;
+const CONTEXT_URL_MAX = 2000;
+const CONTEXT_ERROR_MESSAGE_MAX = 1000;
+const CONTEXT_TOTAL_MAX = 4000;
+
+// Per-user rate limit.
+const RATE_LIMIT_MAX_REQUESTS = 5;
+const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+
+/**
+ * Best-effort, per-user rate limit backed by an in-module Map of request
+ * timestamps. NOTE: this is per-serverless-instance and NOT durable across
+ * instances or cold starts — it is a cheap spam/quota guard, not a hard
+ * guarantee. A distributed store (e.g. Redis) would be required for that.
+ */
+const rateLimitBuckets = new Map<string, number[]>();
+
+function isRateLimited(userId: string, now: number): boolean {
+  const windowStart = now - RATE_LIMIT_WINDOW_MS;
+  const recent = (rateLimitBuckets.get(userId) ?? []).filter(
+    (timestamp) => timestamp > windowStart
+  );
+
+  if (recent.length >= RATE_LIMIT_MAX_REQUESTS) {
+    rateLimitBuckets.set(userId, recent);
+    return true;
+  }
+
+  recent.push(now);
+  rateLimitBuckets.set(userId, recent);
+  return false;
+}
+
+interface ValidatedContext {
+  url?: string;
+  errorMessage?: string;
+}
+
+interface ValidatedSupportRequest {
+  subject: string;
+  message: string;
+  category: SupportCategory;
+  context: ValidatedContext;
+}
+
+type ValidationResult =
+  | { ok: true; value: ValidatedSupportRequest }
+  | { ok: false; error: string };
+
+function isSupportCategory(value: unknown): value is SupportCategory {
+  return (
+    typeof value === "string" &&
+    (SUPPORT_CATEGORIES as readonly string[]).includes(value)
+  );
+}
+
+function validateBody(body: unknown): ValidationResult {
+  if (typeof body !== "object" || body === null) {
+    return { ok: false, error: "Request body must be an object." };
+  }
+
+  const { subject, message, category, context } = body as Record<
+    string,
+    unknown
+  >;
+
+  if (typeof subject !== "string") {
+    return { ok: false, error: "Subject is required." };
+  }
+  const trimmedSubject = subject.trim();
+  if (
+    trimmedSubject.length < SUBJECT_MIN ||
+    trimmedSubject.length > SUBJECT_MAX
+  ) {
+    return {
+      ok: false,
+      error: `Subject must be between ${SUBJECT_MIN} and ${SUBJECT_MAX} characters.`,
+    };
+  }
+
+  if (typeof message !== "string") {
+    return { ok: false, error: "Message is required." };
+  }
+  const trimmedMessage = message.trim();
+  if (
+    trimmedMessage.length < MESSAGE_MIN ||
+    trimmedMessage.length > MESSAGE_MAX
+  ) {
+    return {
+      ok: false,
+      error: `Message must be between ${MESSAGE_MIN} and ${MESSAGE_MAX} characters.`,
+    };
+  }
+
+  if (!isSupportCategory(category)) {
+    return { ok: false, error: "Invalid category." };
+  }
+
+  // Read only known keys from context; ignore everything else.
+  const validatedContext: ValidatedContext = {};
+  if (typeof context === "object" && context !== null) {
+    const { url, errorMessage } = context as Record<string, unknown>;
+    if (typeof url === "string") {
+      if (url.length > CONTEXT_URL_MAX) {
+        return { ok: false, error: "Context URL is too long." };
+      }
+      validatedContext.url = url;
+    }
+    if (typeof errorMessage === "string") {
+      validatedContext.errorMessage = errorMessage.slice(
+        0,
+        CONTEXT_ERROR_MESSAGE_MAX
+      );
+    }
+  }
+
+  if (JSON.stringify(validatedContext).length > CONTEXT_TOTAL_MAX) {
+    return { ok: false, error: "Context is too large." };
+  }
+
+  return {
+    ok: true,
+    value: {
+      subject: trimmedSubject,
+      message: trimmedMessage,
+      category,
+      context: validatedContext,
+    },
+  };
+}
+
+function buildSupportEmailHtml(params: {
+  userId: string;
+  userEmail: string | undefined;
+  subject: string;
+  message: string;
+  category: SupportCategory;
+  context: ValidatedContext;
+}): string {
+  const { userId, userEmail, subject, message, category, context } = params;
+
+  const replyNote = userEmail
+    ? `<p style="margin: 0 0 4px;"><strong>Reply to:</strong> ${escapeHtml(userEmail)}</p>`
+    : `<p style="margin: 0 0 4px; color: #b91c1c;"><strong>No reply address on file</strong> — replies will not reach this user.</p>`;
+
+  const urlRow = context.url
+    ? `<p style="margin: 0 0 4px;"><strong>Page:</strong> <a href="${safeUrl(context.url)}">${escapeHtml(context.url)}</a></p>`
+    : "";
+
+  const errorRow = context.errorMessage
+    ? `<p style="margin: 0 0 4px;"><strong>Error:</strong> ${escapeHtml(context.errorMessage)}</p>`
+    : "";
+
+  return `
+    <h2 style="margin: 0 0 12px;">New support request</h2>
+    <p style="margin: 0 0 4px;"><strong>Category:</strong> ${escapeHtml(category)}</p>
+    <p style="margin: 0 0 4px;"><strong>Subject:</strong> ${escapeHtml(subject)}</p>
+    <p style="margin: 0 0 4px;"><strong>User ID:</strong> ${escapeHtml(userId)}</p>
+    ${replyNote}
+    ${urlRow}
+    ${errorRow}
+    <hr style="margin: 16px 0; border: none; border-top: 1px solid #e4e4e7;" />
+    <p style="margin: 0 0 8px;"><strong>Message:</strong></p>
+    <p style="margin: 0; white-space: pre-wrap;">${escapeHtml(message)}</p>
+  `;
+}
+
+export async function POST(request: NextRequest) {
+  const startTime = Date.now();
+  // Declared in function scope so the catch block can log it safely.
+  let user: Awaited<
+    ReturnType<Awaited<ReturnType<typeof createClient>>["auth"]["getUser"]>
+  >["data"]["user"] = null;
+
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user: authedUser },
+      error: authError,
+    } = await supabase.auth.getUser();
+    user = authedUser;
+
+    if (authError || !user) {
+      loggerService.warn("Unauthorized support request attempt", {
+        category: LogCategory.SECURITY,
+        action: "support_unauthorized",
+      });
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid request body." },
+        { status: 400 }
+      );
+    }
+
+    const validation = validateBody(rawBody);
+    if (!validation.ok) {
+      return NextResponse.json({ error: validation.error }, { status: 400 });
+    }
+
+    if (isRateLimited(user.id, Date.now())) {
+      loggerService.warn("Support request rate limit exceeded", {
+        category: LogCategory.SECURITY,
+        userId: user.id,
+        action: "support_rate_limited",
+      });
+      return NextResponse.json(
+        { error: "Too many support requests. Please try again later." },
+        { status: 429 }
+      );
+    }
+
+    const { subject, message, category, context } = validation.value;
+    const replyTo = user.email ?? undefined;
+
+    const html = buildSupportEmailHtml({
+      userId: user.id,
+      userEmail: user.email ?? undefined,
+      subject,
+      message,
+      category,
+      context,
+    });
+
+    const result = await sendEmail({
+      to: SUPPORT_EMAIL,
+      replyTo,
+      subject: `[Support] [${category}] ${subject}`,
+      html,
+    });
+
+    if ("mock" in result && result.mock === true) {
+      loggerService.info("Support request email mocked (no RESEND_API_KEY)", {
+        category: LogCategory.EMAIL,
+        userId: user.id,
+        action: "support_email_mocked",
+        duration: Date.now() - startTime,
+        metadata: { category },
+      });
+      return NextResponse.json({ success: true });
+    }
+
+    loggerService.info("Support request email sent", {
+      category: LogCategory.EMAIL,
+      userId: user.id,
+      action: "support_email_sent",
+      duration: Date.now() - startTime,
+      metadata: { category },
+    });
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    loggerService.error("Failed to send support request", error, {
+      category: LogCategory.API,
+      userId: user?.id,
+      action: "support_error",
+      duration: Date.now() - startTime,
+    });
+    return NextResponse.json(
+      { error: "Failed to send support request." },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/support/route.ts
+++ b/app/api/support/route.ts
@@ -5,16 +5,16 @@ import { escapeHtml, safeUrl } from "@/lib/email/transactional";
 import {
   SUPPORT_EMAIL,
   SUPPORT_CATEGORIES,
+  SUPPORT_LIMITS,
   type SupportCategory,
 } from "@/lib/constants/site-config";
 import { loggerService } from "@/lib/services/logger.service";
 import { LogCategory } from "@/lib/services/logger.types";
 
-// Validation caps (named to avoid magic numbers).
-const SUBJECT_MIN = 1;
-const SUBJECT_MAX = 200;
-const MESSAGE_MIN = 1;
-const MESSAGE_MAX = 5000;
+// Subject/message caps are shared with the client form via SUPPORT_LIMITS.
+const { subjectMin: SUBJECT_MIN, subjectMax: SUBJECT_MAX } = SUPPORT_LIMITS;
+const { messageMin: MESSAGE_MIN, messageMax: MESSAGE_MAX } = SUPPORT_LIMITS;
+// Context caps are server-only (named to avoid magic numbers).
 const CONTEXT_URL_MAX = 2000;
 const CONTEXT_ERROR_MESSAGE_MAX = 1000;
 const CONTEXT_TOTAL_MAX = 4000;
@@ -251,6 +251,27 @@ export async function POST(request: NextRequest) {
     });
 
     if ("mock" in result && result.mock === true) {
+      // In production a mocked send means RESEND_API_KEY is missing and the
+      // request would be silently dropped — fail closed so the user knows it
+      // didn't go through. In dev/test, mock mode is expected, so report success.
+      if (process.env.NODE_ENV === "production") {
+        loggerService.error(
+          "Support email mocked in production (RESEND_API_KEY missing)",
+          undefined,
+          {
+            category: LogCategory.EMAIL,
+            userId: user.id,
+            action: "support_email_mocked_in_production",
+            duration: Date.now() - startTime,
+            metadata: { category },
+          }
+        );
+        return NextResponse.json(
+          { success: false, error: "Email delivery is not configured." },
+          { status: 500 }
+        );
+      }
+
       loggerService.info("Support request email mocked (no RESEND_API_KEY)", {
         category: LogCategory.EMAIL,
         userId: user.id,

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { SUPPORT_EMAIL } from "@/lib/constants/site-config";
+
+interface GlobalErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+/**
+ * Last-resort backstop for errors in the root layout that `(app)/error.tsx`
+ * cannot catch. The app shell (providers, components, Tailwind) may be
+ * unavailable here, so this UI is fully self-contained with inline styles and a
+ * plain `mailto:` support affordance.
+ */
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+  const handleReload = () => {
+    reset();
+    window.location.reload();
+  };
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily:
+            "system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif",
+          backgroundColor: "#ffffff",
+          color: "#111827",
+          padding: "24px",
+        }}
+      >
+        <div
+          role="alert"
+          aria-live="assertive"
+          style={{ maxWidth: "32rem", width: "100%" }}
+        >
+          <h1 style={{ fontSize: "1.5rem", fontWeight: 600, margin: "0 0 12px" }}>
+            Something went wrong
+          </h1>
+          <p style={{ fontSize: "0.95rem", lineHeight: 1.5, margin: "0 0 20px", color: "#374151" }}>
+            We hit an unexpected problem and could not load the app. Please reload
+            the page. If the problem continues, contact our support team.
+          </p>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: "12px" }}>
+            <button
+              type="button"
+              onClick={handleReload}
+              style={{
+                minHeight: "44px",
+                padding: "0 20px",
+                borderRadius: "8px",
+                border: "none",
+                backgroundColor: "#111827",
+                color: "#ffffff",
+                fontSize: "0.95rem",
+                fontWeight: 500,
+                cursor: "pointer",
+              }}
+            >
+              Reload
+            </button>
+            <a
+              href={`mailto:${SUPPORT_EMAIL}`}
+              style={{
+                minHeight: "44px",
+                display: "inline-flex",
+                alignItems: "center",
+                padding: "0 20px",
+                borderRadius: "8px",
+                border: "1px solid #d1d5db",
+                color: "#111827",
+                fontSize: "0.95rem",
+                fontWeight: 500,
+                textDecoration: "none",
+              }}
+            >
+              Contact support
+            </a>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/components/accessibility/error-boundary.tsx
+++ b/components/accessibility/error-boundary.tsx
@@ -1,6 +1,8 @@
+"use client";
+
 /**
  * Accessibility-Focused Error Boundary Component
- * 
+ *
  * Provides graceful error handling with accessibility features:
  * - Announces errors to screen readers
  * - Provides keyboard-accessible recovery options

--- a/components/ai-coach/ApplicationAIAnalysis.tsx
+++ b/components/ai-coach/ApplicationAIAnalysis.tsx
@@ -55,6 +55,8 @@ import {
   copyAnalysisToClipboard,
   downloadAnalysisPDF,
 } from "@/lib/utils/analysis-export";
+import { SectionErrorBoundary } from "@/components/accessibility/error-boundary";
+import { SupportErrorFallback } from "@/components/support/support-error-fallback";
 import { JobFitAnalysisResult as JobFitAnalysisDisplay } from "@/components/ai-coach/results/JobFitAnalysisResult";
 import { InterviewPreparationResult as InterviewPreparationDisplay } from "@/components/ai-coach/results/InterviewPreparationResult";
 import { CoverLetterResult as CoverLetterDisplay } from "@/components/ai-coach/results/CoverLetterResult";
@@ -357,6 +359,10 @@ export function ApplicationAIAnalysis({
   }
 
   return (
+    <SectionErrorBoundary
+      name="Application AI Analysis"
+      fallback={<SupportErrorFallback name="Application AI Analysis" />}
+    >
     <Card className={`overflow-hidden ${className || ""}`}>
       <CardHeader className="pb-4">
         <CardTitle className="flex items-center gap-2 text-primary">
@@ -704,5 +710,6 @@ export function ApplicationAIAnalysis({
         </CardContent>
       </div>
     </Card>
+    </SectionErrorBoundary>
   );
 }

--- a/components/ai-coach/ai-coach-dashboard.tsx
+++ b/components/ai-coach/ai-coach-dashboard.tsx
@@ -22,6 +22,8 @@ import { useTrialBudget } from "@/hooks/use-trial-budget";
 import { TrialOnboarding } from "./trial-onboarding";
 import { TrialBudgetCounter } from "./trial-budget-counter";
 import { TrialBudgetNudge } from "./trial-budget-nudge";
+import { SectionErrorBoundary } from "@/components/accessibility/error-boundary";
+import { SupportErrorFallback } from "@/components/support/support-error-fallback";
 
 interface AICoachDashboardProps {
   userId: string;
@@ -147,23 +149,48 @@ function AICoachDashboardInner({ userId }: AICoachDashboardProps) {
         </div>
 
         <TabsContent value="resume" className="space-y-6">
-          <ResumeAnalyzer userId={userId} />
+          <SectionErrorBoundary
+            name="Resume"
+            fallback={<SupportErrorFallback name="Resume" />}
+          >
+            <ResumeAnalyzer userId={userId} />
+          </SectionErrorBoundary>
         </TabsContent>
 
         <TabsContent value="interview" className="space-y-6">
-          <InterviewPrep />
+          <SectionErrorBoundary
+            name="Interview"
+            fallback={<SupportErrorFallback name="Interview" />}
+          >
+            <InterviewPrep />
+          </SectionErrorBoundary>
         </TabsContent>
 
         <TabsContent value="cover-letter" className="space-y-6">
-          <CoverLetterGenerator />
+          <SectionErrorBoundary
+            name="Cover Letter"
+            fallback={<SupportErrorFallback name="Cover Letter" />}
+          >
+            <CoverLetterGenerator />
+          </SectionErrorBoundary>
         </TabsContent>
 
         <TabsContent value="job-fit" className="space-y-6">
-          <JobFitAnalysis />
+          <SectionErrorBoundary
+            name="Job Fit"
+            fallback={<SupportErrorFallback name="Job Fit" />}
+          >
+            <JobFitAnalysis />
+          </SectionErrorBoundary>
         </TabsContent>
 
         <TabsContent value="advice" className="space-y-6">
-          <CareerAdvice />
+          <SectionErrorBoundary
+            name="Advice"
+            fallback={<SupportErrorFallback name="Advice" />}
+          >
+            <CareerAdvice />
+          </SectionErrorBoundary>
         </TabsContent>
       </Tabs>
 

--- a/components/ai-coach/career-advice.tsx
+++ b/components/ai-coach/career-advice.tsx
@@ -45,6 +45,7 @@ import {
   Square,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { capturePostHogEvent } from "@/lib/analytics/posthog";
 import type { Conversation } from "@/types";
 
 interface ConversationWithPreview extends Conversation {
@@ -126,7 +127,8 @@ export function CareerAdvice() {
     setMessages,
     status,
     error,
-    reload,
+    regenerate,
+    clearError,
     stop,
   } = useChat({
     transport,
@@ -281,6 +283,21 @@ export function CareerAdvice() {
     } catch (err) {
       console.error("Failed to send message:", err);
       setChatInput(messageText); // Restore input on error
+    }
+  };
+
+  // Retry the failed request after a chat error. In the error state the last
+  // message is the user's send whose assistant response failed; regenerate()
+  // with no messageId keeps that user message and re-fires the request (verified
+  // against ai@6 AbstractChat.regenerate). clearError dismisses the stale banner.
+  const handleRetry = async () => {
+    clearError();
+    try {
+      await regenerate();
+      capturePostHogEvent("ai_chat_retry_clicked", { outcome: "success" });
+    } catch (err) {
+      console.error("Failed to retry message:", err);
+      capturePostHogEvent("ai_chat_retry_clicked", { outcome: "failure" });
     }
   };
 
@@ -683,7 +700,7 @@ export function CareerAdvice() {
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={() => reload()}
+                  onClick={handleRetry}
                   className="h-7 text-xs"
                 >
                   <RefreshCw className="h-3 w-3 mr-1" />

--- a/components/mobile-navigation.tsx
+++ b/components/mobile-navigation.tsx
@@ -188,7 +188,7 @@ export function MobileNavigation({
               setIsOpen(false);
               setIsSupportOpen(true);
             }}
-            className="w-full flex items-center gap-3 px-3 py-2 rounded-md text-sm hover:bg-accent/50 transition-colors text-left"
+            className="w-full flex items-center gap-3 px-3 py-2 min-h-[44px] rounded-md text-sm hover:bg-accent/50 transition-colors text-left"
           >
             <LifeBuoy className="h-4 w-4" />
             <span>Help / Contact support</span>

--- a/components/mobile-navigation.tsx
+++ b/components/mobile-navigation.tsx
@@ -21,9 +21,11 @@ import {
   Sparkles,
   Shield,
   Flame,
+  LifeBuoy,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { signOut } from "@/lib/actions";
+import { SupportDialog } from "@/components/support/support-dialog";
 import {
   NAV_ITEMS,
   AI_COACH_COLORS,
@@ -51,6 +53,7 @@ export function MobileNavigation({
   isAdmin = false,
 }: MobileNavigationProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const [isSupportOpen, setIsSupportOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const pathname = usePathname();
   const router = useRouter();
@@ -75,6 +78,7 @@ export function MobileNavigation({
   };
 
   return (
+    <>
     <Sheet open={isOpen} onOpenChange={setIsOpen}>
       <SheetTrigger asChild>
         <Button
@@ -179,6 +183,18 @@ export function MobileNavigation({
           )}
 
           <button
+            type="button"
+            onClick={() => {
+              setIsOpen(false);
+              setIsSupportOpen(true);
+            }}
+            className="w-full flex items-center gap-3 px-3 py-2 rounded-md text-sm hover:bg-accent/50 transition-colors text-left"
+          >
+            <LifeBuoy className="h-4 w-4" />
+            <span>Help / Contact support</span>
+          </button>
+
+          <button
             onClick={handleSignOut}
             disabled={loading}
             className="w-full flex items-center gap-3 px-3 py-2 rounded-md text-sm hover:bg-accent/50 transition-colors text-left"
@@ -189,5 +205,7 @@ export function MobileNavigation({
         </div>
       </SheetContent>
     </Sheet>
+    <SupportDialog open={isSupportOpen} onOpenChange={setIsSupportOpen} />
+    </>
   );
 }

--- a/components/support/support-dialog.tsx
+++ b/components/support/support-dialog.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { SupportForm } from "@/components/support/support-form";
+
+interface SupportDialogProps {
+  /** Optional trigger element; rendered inside a DialogTrigger when provided. */
+  trigger?: ReactNode;
+  /** Controlled open state. Omit to let the dialog manage its own state. */
+  open?: boolean;
+  /** Controlled open-change handler, required when using controlled `open`. */
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function SupportDialog({
+  trigger,
+  open,
+  onOpenChange,
+}: SupportDialogProps) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+
+  const isControlled = open !== undefined;
+  const isOpen = isControlled ? open : uncontrolledOpen;
+
+  function setOpen(next: boolean) {
+    if (isControlled) {
+      onOpenChange?.(next);
+    } else {
+      setUncontrolledOpen(next);
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setOpen}>
+      {trigger ? <DialogTrigger asChild>{trigger}</DialogTrigger> : null}
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Contact support</DialogTitle>
+          <DialogDescription>
+            Tell us what's going on and we'll reply to your account email.
+          </DialogDescription>
+        </DialogHeader>
+        <SupportForm source="nav" onDone={() => setOpen(false)} />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/support/support-error-fallback.tsx
+++ b/components/support/support-error-fallback.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { capturePostHogEvent } from "@/lib/analytics/posthog";
+
+// Cap the error message we forward to the support page so the URL stays sane.
+const MAX_ERROR_MESSAGE_LENGTH = 300;
+
+const SUPPORT_PATH = "/dashboard/support";
+
+interface SupportErrorFallbackProps {
+  /** Human-readable name of the boundary, used for messaging and analytics. */
+  name?: string;
+  /** The error that triggered the boundary, if available. */
+  error?: Error;
+  /**
+   * Recovery callback (e.g. Next.js `reset`). When absent the fallback performs
+   * a full page reload. It must never silently re-render the same subtree, which
+   * would infinite-loop on deterministic errors.
+   */
+  reset?: () => void;
+}
+
+function buildSupportHref(error?: Error): string {
+  const message = error?.message;
+  if (!message) return SUPPORT_PATH;
+
+  const truncated = message.slice(0, MAX_ERROR_MESSAGE_LENGTH);
+  return `${SUPPORT_PATH}?errorMessage=${encodeURIComponent(truncated)}`;
+}
+
+/**
+ * Accessible fallback UI for error boundaries.
+ *
+ * When a custom `fallback` is passed to `AccessibleErrorBoundary`, it is
+ * rendered directly and the boundary's built-in role/aria/focus handling is
+ * bypassed. This component therefore re-implements those a11y traits itself.
+ */
+export function SupportErrorFallback({
+  name,
+  error,
+  reset,
+}: SupportErrorFallbackProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const hasTrackedRef = useRef(false);
+
+  // Move focus to the alert so screen readers announce it immediately.
+  useEffect(() => {
+    containerRef.current?.focus();
+  }, []);
+
+  // Fire the analytics event exactly once per mount. Wrap in try/catch so a
+  // throwing analytics call can never defeat the boundary it lives inside.
+  useEffect(() => {
+    if (hasTrackedRef.current) return;
+    hasTrackedRef.current = true;
+    try {
+      capturePostHogEvent("error_boundary_triggered", {
+        boundary: name,
+        message: error?.message,
+      });
+    } catch {
+      // Intentionally swallowed: a fallback must not throw.
+    }
+  }, [name, error]);
+
+  const handleRecover = () => {
+    if (reset) {
+      reset();
+      return;
+    }
+    window.location.reload();
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      role="alert"
+      aria-live="assertive"
+      tabIndex={-1}
+      className="rounded-lg border border-border bg-muted/40 p-6 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+    >
+      <div className="space-y-3">
+        <h2 className="text-lg font-semibold text-foreground">
+          Something went wrong
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          {name
+            ? `We hit an unexpected problem in ${name}. The rest of the app should still work.`
+            : "We hit an unexpected problem. The rest of the app should still work."}
+          {" "}
+          You can try again, or contact support if it keeps happening.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <Button
+            type="button"
+            onClick={handleRecover}
+            className="min-h-11"
+          >
+            Try again
+          </Button>
+          <Button asChild variant="outline" className="min-h-11">
+            <a href={buildSupportHref(error)}>Contact support</a>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SupportErrorFallback;

--- a/components/support/support-error-fallback.tsx
+++ b/components/support/support-error-fallback.tsx
@@ -4,8 +4,8 @@ import { useEffect, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { capturePostHogEvent } from "@/lib/analytics/posthog";
 
-// Cap the error message we forward to the support page so the URL stays sane.
-const MAX_ERROR_MESSAGE_LENGTH = 300;
+// Cap the safe token we forward to the support page so the URL stays sane.
+const MAX_ERROR_TOKEN_LENGTH = 100;
 
 const SUPPORT_PATH = "/dashboard/support";
 
@@ -22,12 +22,15 @@ interface SupportErrorFallbackProps {
   reset?: () => void;
 }
 
+// Forward only the error *name* (e.g. "TypeError"), never the message. The
+// message can contain user/PII data and would leak into the URL — and thus
+// browser history, server logs, and PostHog's `$current_url` autocapture.
 function buildSupportHref(error?: Error): string {
-  const message = error?.message;
-  if (!message) return SUPPORT_PATH;
+  const name = error?.name;
+  if (!name) return SUPPORT_PATH;
 
-  const truncated = message.slice(0, MAX_ERROR_MESSAGE_LENGTH);
-  return `${SUPPORT_PATH}?errorMessage=${encodeURIComponent(truncated)}`;
+  const safeToken = name.slice(0, MAX_ERROR_TOKEN_LENGTH);
+  return `${SUPPORT_PATH}?errorMessage=${encodeURIComponent(safeToken)}`;
 }
 
 /**

--- a/components/support/support-form.tsx
+++ b/components/support/support-form.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
+import { capturePostHogEvent } from "@/lib/analytics/posthog";
+import {
+  SUPPORT_CATEGORIES,
+  type SupportCategory,
+} from "@/lib/constants/site-config";
+
+// Mirror the server-side caps in app/api/support/route.ts so the client blocks
+// invalid input before a round-trip. Keep these in sync with the route.
+const SUBJECT_MAX = 200;
+const MESSAGE_MAX = 5000;
+
+const DEFAULT_CATEGORY: SupportCategory = SUPPORT_CATEGORIES[0];
+
+type SubmitStatus = "idle" | "submitting" | "success" | "error";
+
+type SupportFormSource = "nav" | "error_fallback" | "page";
+
+interface SupportFormProps {
+  source: SupportFormSource;
+  initialContext?: { errorMessage?: string };
+  onDone?: () => void;
+}
+
+interface SupportRequestBody {
+  category: SupportCategory;
+  subject: string;
+  message: string;
+  context: {
+    url: string;
+    errorMessage?: string;
+  };
+}
+
+function buildFailureReason(status: number | "network"): string {
+  return status === "network" ? "network_error" : `http_${status}`;
+}
+
+export function SupportForm({
+  source,
+  initialContext,
+  onDone,
+}: SupportFormProps) {
+  const { toast } = useToast();
+  const [category, setCategory] = useState<SupportCategory>(DEFAULT_CATEGORY);
+  const [subject, setSubject] = useState("");
+  const [message, setMessage] = useState("");
+  const [status, setStatus] = useState<SubmitStatus>("idle");
+  const [errorText, setErrorText] = useState<string | null>(null);
+
+  // Fire the "opened" analytics event exactly once per mount.
+  const hasTrackedOpen = useRef(false);
+  useEffect(() => {
+    if (hasTrackedOpen.current) return;
+    hasTrackedOpen.current = true;
+    capturePostHogEvent("support_form_opened", { source });
+  }, [source]);
+
+  const trimmedSubject = subject.trim();
+  const trimmedMessage = message.trim();
+  const isSubjectValid =
+    trimmedSubject.length > 0 && subject.length <= SUBJECT_MAX;
+  const isMessageValid =
+    trimmedMessage.length > 0 && message.length <= MESSAGE_MAX;
+  const isSubmitting = status === "submitting";
+  const canSubmit = isSubjectValid && isMessageValid && !isSubmitting;
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canSubmit) return;
+
+    setStatus("submitting");
+    setErrorText(null);
+
+    const body: SupportRequestBody = {
+      category,
+      subject: trimmedSubject,
+      message: trimmedMessage,
+      context: {
+        url: window.location.href,
+        ...(initialContext?.errorMessage
+          ? { errorMessage: initialContext.errorMessage }
+          : {}),
+      },
+    };
+
+    let response: Response;
+    try {
+      response = await fetch("/api/support", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+    } catch {
+      const reason = buildFailureReason("network");
+      capturePostHogEvent("support_request_failed", { reason });
+      setStatus("error");
+      setErrorText(
+        "We couldn't reach support. Check your connection and try again."
+      );
+      toast({
+        title: "Could not send",
+        description: "Please check your connection and try again.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (!response.ok) {
+      const reason = buildFailureReason(response.status);
+      capturePostHogEvent("support_request_failed", { reason });
+      setStatus("error");
+      setErrorText(
+        "Something went wrong sending your request. Please try again."
+      );
+      toast({
+        title: "Could not send",
+        description: "Something went wrong. Please try again.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    capturePostHogEvent("support_request_submitted", { category });
+    setStatus("success");
+    toast({
+      title: "Message sent",
+      description: "We received your request and will reply by email.",
+    });
+    onDone?.();
+  }
+
+  if (status === "success") {
+    return (
+      <div className="space-y-2" role="status" aria-live="polite">
+        <p className="text-sm font-medium text-foreground">
+          Thanks, your message was sent.
+        </p>
+        <p className="text-sm text-muted-foreground">
+          Our team will reply to your account email as soon as possible.
+        </p>
+      </div>
+    );
+  }
+
+  const subjectRemaining = SUBJECT_MAX - subject.length;
+  const messageRemaining = MESSAGE_MAX - message.length;
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+      <div className="space-y-2">
+        <Label htmlFor="support-category">Category</Label>
+        <Select
+          value={category}
+          onValueChange={(value) => setCategory(value as SupportCategory)}
+          disabled={isSubmitting}
+        >
+          <SelectTrigger id="support-category" className="min-h-11">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {SUPPORT_CATEGORIES.map((option) => (
+              <SelectItem key={option} value={option}>
+                {option}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="support-subject">Subject</Label>
+        <Input
+          id="support-subject"
+          value={subject}
+          maxLength={SUBJECT_MAX}
+          disabled={isSubmitting}
+          onChange={(event) => setSubject(event.target.value)}
+          placeholder="Brief summary of your issue"
+          aria-describedby="support-subject-help"
+        />
+        <p
+          id="support-subject-help"
+          className="text-xs text-muted-foreground"
+        >
+          {subjectRemaining} characters remaining
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="support-message">Message</Label>
+        <Textarea
+          id="support-message"
+          value={message}
+          maxLength={MESSAGE_MAX}
+          disabled={isSubmitting}
+          onChange={(event) => setMessage(event.target.value)}
+          placeholder="Tell us what happened and what you expected"
+          className="min-h-32"
+          aria-describedby="support-message-help"
+        />
+        <p
+          id="support-message-help"
+          className="text-xs text-muted-foreground"
+        >
+          {messageRemaining} characters remaining
+        </p>
+      </div>
+
+      {errorText ? (
+        <p className="text-sm text-destructive" role="alert">
+          {errorText}
+        </p>
+      ) : null}
+
+      <Button type="submit" disabled={!canSubmit} className="w-full sm:w-auto">
+        {isSubmitting ? "Sending..." : "Send message"}
+      </Button>
+    </form>
+  );
+}

--- a/components/support/support-form.tsx
+++ b/components/support/support-form.tsx
@@ -16,15 +16,19 @@ import { useToast } from "@/hooks/use-toast";
 import { capturePostHogEvent } from "@/lib/analytics/posthog";
 import {
   SUPPORT_CATEGORIES,
+  SUPPORT_LIMITS,
   type SupportCategory,
 } from "@/lib/constants/site-config";
 
-// Mirror the server-side caps in app/api/support/route.ts so the client blocks
-// invalid input before a round-trip. Keep these in sync with the route.
-const SUBJECT_MAX = 200;
-const MESSAGE_MAX = 5000;
+// Shared with the API route (app/api/support) via SUPPORT_LIMITS so the client
+// blocks invalid input before a round-trip without the caps drifting.
+const { subjectMax: SUBJECT_MAX, messageMax: MESSAGE_MAX } = SUPPORT_LIMITS;
 
 const DEFAULT_CATEGORY: SupportCategory = SUPPORT_CATEGORIES[0];
+
+function isSupportCategory(value: string): value is SupportCategory {
+  return (SUPPORT_CATEGORIES as readonly string[]).includes(value);
+}
 
 type SubmitStatus = "idle" | "submitting" | "success" | "error";
 
@@ -166,7 +170,9 @@ export function SupportForm({
         <Label htmlFor="support-category">Category</Label>
         <Select
           value={category}
-          onValueChange={(value) => setCategory(value as SupportCategory)}
+          onValueChange={(value) => {
+            if (isSupportCategory(value)) setCategory(value);
+          }}
           disabled={isSubmitting}
         >
           <SelectTrigger id="support-category" className="min-h-11">

--- a/components/user-menu.tsx
+++ b/components/user-menu.tsx
@@ -7,11 +7,13 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { User, LogOut, Crown, Settings, Shield } from "lucide-react";
+import { User, LogOut, Crown, Settings, Shield, LifeBuoy } from "lucide-react";
 import Link from "next/link";
 import { signOut } from "@/lib/actions";
+import { SupportDialog } from "@/components/support/support-dialog";
 import type { User as SupabaseUser } from "@supabase/supabase-js";
 import type { Profile } from "@/lib/supabase";
 
@@ -24,6 +26,7 @@ interface UserMenuProps {
 
 export function UserMenu({ user, profile, isOnFreePlan, isAdmin = false }: UserMenuProps) {
   const [loading, setLoading] = useState(false);
+  const [isSupportOpen, setIsSupportOpen] = useState(false);
   const router = useRouter();
 
   // Helper function to get display name with proper truncation
@@ -60,6 +63,7 @@ export function UserMenu({ user, profile, isOnFreePlan, isAdmin = false }: UserM
   };
 
   return (
+    <>
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button variant="ghost" size="sm" className="max-w-[200px]">
@@ -98,11 +102,29 @@ export function UserMenu({ user, profile, isOnFreePlan, isAdmin = false }: UserM
           </Link>
         )}
 
+        <DropdownMenuSeparator />
+
+        <DropdownMenuItem
+          onSelect={(event) => {
+            // Prevent the menu from stealing focus as it closes, which can
+            // race with the dialog mounting and swallow the open.
+            event.preventDefault();
+            setIsSupportOpen(true);
+          }}
+        >
+          <LifeBuoy className="h-4 w-4 mr-2" />
+          Help / Contact support
+        </DropdownMenuItem>
+
+        <DropdownMenuSeparator />
+
         <DropdownMenuItem onClick={handleSignOut} disabled={loading}>
           <LogOut className="h-4 w-4 mr-2" />
           {loading ? "Signing out..." : "Logout"}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
+    <SupportDialog open={isSupportOpen} onOpenChange={setIsSupportOpen} />
+    </>
   );
 }

--- a/docs/ai-coach-job-fit-onclick-crash.md
+++ b/docs/ai-coach-job-fit-onclick-crash.md
@@ -19,7 +19,7 @@ On `/dashboard/ai-coach?tab=job-fit&applicationId=…`, clicking a button in the
 
 ## Stack (mangled — sourcemaps missing)
 Top frame is `onClick` in:
-```
+```text
 /_next/static/chunks/app/(app)/dashboard/ai-coach/page-85fa627d3bb58727.js
 ```
 Calls into shared chunk `/_next/static/chunks/5bfbefed-7fac4e9d5299b08f.js` at functions `iG → ? → nS → i4 → ce → s9`.

--- a/docs/ai-coach-job-fit-onclick-crash.md
+++ b/docs/ai-coach-job-fit-onclick-crash.md
@@ -1,0 +1,94 @@
+# AI Coach job-fit tab — `TypeError: $ is not a function` on click
+
+## Status
+Resolved (2026-05-28). Root cause identified from the PostHog session below; fix shipped along with
+an in-app support form and app-wide error boundaries. See "Resolution" at the bottom.
+
+> Note: the title says "job-fit tab", but the crash was actually on the **Advice** tab. The exception
+> `$current_url` read `tab=job-fit` because the tab switch updates React state immediately while the
+> URL query param lags — the rendered component when it crashed was the Advice chat.
+
+## PostHog references
+- Error tracking issue: `019e6fb9-b0c2-74f2-bb76-183fa419c871`
+- Example session: `019e6fac-b613-7a65-8e73-f9f77ba26ccf`
+- Example person (paying user): `2155c5d7-234e-5e1c-a6ee-50be99dbe97d` (distinct_id `019e6fac-b616-7c4a-be40-a377df6c8350`)
+- Vercel deployment ID at time of crash: `dpl_3taUfhvBMFATmhmLQpuuVhzW9MJ3`
+
+## What happens
+On `/dashboard/ai-coach?tab=job-fit&applicationId=…`, clicking a button in the job-fit tab throws an unhandled `TypeError: $ is not a function`. The user clicked once, got no visible response, then rage-clicked — PostHog captured a `$rageclick` and ~10 identical exceptions fired in roughly one second. The user then navigated away from AI Coach back to the application detail page.
+
+## Stack (mangled — sourcemaps missing)
+Top frame is `onClick` in:
+```
+/_next/static/chunks/app/(app)/dashboard/ai-coach/page-85fa627d3bb58727.js
+```
+Calls into shared chunk `/_next/static/chunks/5bfbefed-7fac4e9d5299b08f.js` at functions `iG → ? → nS → i4 → ce → s9`.
+
+Exception list:
+```json
+{ "type": "TypeError", "value": "$ is not a function", "mechanism": { "handled": false } }
+```
+
+## Why we can't see the real symbol
+PostHog reports `Could not find sourcemap for source url` for both `5bfbefed-…js` and the ai-coach page chunk for deployment `dpl_3taUfhvBMFATmhmLQpuuVhzW9MJ3`. Sourcemap upload to PostHog is either not running or not running for this build. Until that's fixed, `$` is just a mangled name — could be jQuery, a lodash/utility shorthand, a tree-shaken default export, or an unresolved dynamic import.
+
+## Likely causes to investigate
+1. A utility imported as `$` (e.g. a chart, parser, or fetch helper) is `undefined` at runtime — tree-shaking or a wrong named-vs-default import after a recent change to the job-fit tab.
+2. A library expected on `window.$` (jQuery-style) is not loaded on this route.
+3. A conditional/dynamic import resolves to `undefined` and is then called.
+
+## User impact
+This user had just paid (Stripe live session `cs_live_b1ZCxC2DwEMh4Hdcbv8ToVdiKQKiHQ05pyC22kS3VIDTaokU2y80pQBv58`) and was on their first real use of AI Coach. They hit the bug ~10 minutes after upgrading. This is a churn risk on the feature people are paying for.
+
+Feature flags on the affected session:
+- `conversion-hero-copy=control`
+- `dashboard-ux-audit-v1=true`
+- `show-testimonials=false`
+
+## Suggested next steps
+1. Upload sourcemaps for `dpl_3taUfhvBMFATmhmLQpuuVhzW9MJ3` (or wire sourcemap upload into the Vercel build) so the issue resolves to a real symbol and line.
+2. Re-open `/dashboard/ai-coach?tab=job-fit&applicationId=…` against a recent application and click through every button on the job-fit tab — the offending handler is in `app/(app)/dashboard/ai-coach/page.tsx` or one of its imports.
+3. Watch session `019e6fac-b613-7a65-8e73-f9f77ba26ccf` in PostHog to see which button the user clicked.
+4. Once identified, check recent git history on the job-fit tab for an import that changed shape (default → named, or removed).
+
+---
+
+## Resolution (2026-05-28)
+
+### Confirmed root cause
+The clicked element was the **chat "Retry" button on the AI Coach → Advice tab**, not the job-fit
+tab. PostHog autocapture shows the `$el_text` on every exception (and the `$rageclick`) was `Retry`;
+the user had submitted a chat message that errored, which renders the error UI's Retry button.
+
+`components/ai-coach/career-advice.tsx` destructured `reload` from `useChat` and called it in the
+Retry handler:
+```tsx
+const { ..., reload, ... } = useChat({ ... });
+// ...
+<Button onClick={() => reload()}>Retry</Button>
+```
+The project runs `@ai-sdk/react@3` / `ai@6`, where `useChat`'s `reload` was **removed and replaced by
+`regenerate`** (verified in the installed SDK type defs and `AbstractChat.regenerate` source). So
+`reload` was `undefined`, and clicking Retry called `undefined()` → `TypeError: reload is not a
+function`, minified to `$ is not a function`. It was the only `reload` usage in the app.
+
+### Fix
+- `career-advice.tsx`: destructure `regenerate` and `clearError` instead of `reload`; the Retry
+  handler now clears the stale error banner and re-fires the failed request via `regenerate()`
+  (verified to re-submit from the last user message in the error state). Emits an
+  `ai_chat_retry_clicked` analytics event with the outcome.
+
+### Shipped alongside (hardening so a future crash isn't a dead end)
+- **In-app support form** emailing `support@apptrack.ing` (reply-to = the user): `POST /api/support`
+  (auth + validation + rate limit + HTML-escaped body via the shared Resend `sendEmail` helper), a
+  shared `SupportForm`, a `SupportDialog` wired into the desktop user menu and mobile nav, and a
+  standalone `/dashboard/support` page.
+- **Error boundaries**: a shared accessible `SupportErrorFallback` (recovery action + "Contact
+  support" link, fires an `error_boundary_triggered` event); each of the five AI Coach tabs wrapped
+  in `SectionErrorBoundary`; `ApplicationAIAnalysis` wrapped; plus route-level `app/(app)/error.tsx`
+  and last-resort `app/global-error.tsx` (which previously did not exist anywhere in the app).
+
+### Still open (separate from this fix)
+- PostHog **sourcemap upload** for production builds is still not running, which is why this issue
+  resolved only to the mangled symbol `$`. Worth wiring into the Vercel build so future exceptions
+  resolve to real symbols/lines. (Original suggested step 1 below.)

--- a/lib/constants/site-config.ts
+++ b/lib/constants/site-config.ts
@@ -31,3 +31,15 @@ export const SITE_CONFIG = {
 } as const;
 
 export type SiteConfig = typeof SITE_CONFIG;
+
+export const SUPPORT_EMAIL = "support@apptrack.ing";
+
+export const SUPPORT_CATEGORIES = [
+  "Bug / something broke",
+  "Billing",
+  "Feature request",
+  "Account",
+  "Other",
+] as const;
+
+export type SupportCategory = (typeof SUPPORT_CATEGORIES)[number];

--- a/lib/constants/site-config.ts
+++ b/lib/constants/site-config.ts
@@ -43,3 +43,12 @@ export const SUPPORT_CATEGORIES = [
 ] as const;
 
 export type SupportCategory = (typeof SUPPORT_CATEGORIES)[number];
+
+// Single source of truth for support message limits, shared by the client form
+// (components/support/support-form.tsx) and the API route (app/api/support).
+export const SUPPORT_LIMITS = {
+  subjectMin: 1,
+  subjectMax: 200,
+  messageMin: 1,
+  messageMax: 5000,
+} as const;

--- a/lib/email/client.ts
+++ b/lib/email/client.ts
@@ -12,11 +12,13 @@ export async function sendEmail({
   subject,
   html,
   from = process.env.FROM_EMAIL || 'AppTrack <onboarding@resend.dev>',
+  replyTo,
 }: {
   to: string;
   subject: string;
   html: string;
   from?: string;
+  replyTo?: string;
 }) {
   if (!resend) {
     return { success: true, mock: true };
@@ -28,6 +30,7 @@ export async function sendEmail({
       to,
       subject,
       html,
+      ...(replyTo ? { replyTo } : {}),
     });
 
     if (error) {

--- a/lib/email/transactional.ts
+++ b/lib/email/transactional.ts
@@ -15,7 +15,7 @@ const APP_URL =
   'https://www.apptrack.ing';
 
 /** Escape special HTML characters to prevent XSS via user-controlled strings. */
-function escapeHtml(str: string): string {
+export function escapeHtml(str: string): string {
   return str
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
@@ -28,7 +28,7 @@ function escapeHtml(str: string): string {
  * Validate and return a safe URL for use in href attributes.
  * Only allows http/https schemes; falls back to '#' for anything else.
  */
-function safeUrl(url: string): string {
+export function safeUrl(url: string): string {
   try {
     const parsed = new URL(url);
     if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {


### PR DESCRIPTION
## Why

A paying user, minutes after upgrading, hit an unhandled `TypeError: $ is not a function` on the AI Coach **Advice** tab, got a dead button, rage-clicked ~10×, and abandoned the feature. Confirmed via PostHog session `019e6fac-…` / error issue `019e6fb9-…`.

## Root cause

The clicked element was the chat **"Retry"** button. `components/ai-coach/career-advice.tsx` destructured `reload` from `useChat` and called it on Retry — but `@ai-sdk/react@3` / `ai@6` removed `reload` (renamed to `regenerate`), so `reload` was `undefined` and `reload()` threw (minified to `$ is not a function`). It was the only `reload` usage in the app. (The exception's `$current_url` read `tab=job-fit` because the tab switch updates React state immediately while the URL query param lags — the crash was on the Advice chat.)

## What's in this PR

**The fix**
- `career-advice.tsx`: use `regenerate` + `clearError`; Retry now clears the stale error banner and re-fires the failed request. Verified against the installed SDK that `regenerate()` re-submits in the error state.

**In-app support** (emails `support@apptrack.ing`, reply-to = the user)
- `POST /api/support`: auth, validation, per-user rate limit, HTML-escaped body via the existing Resend `sendEmail` (added optional `replyTo`).
- Shared `SupportForm`, `SupportDialog` wired into the desktop user menu + mobile nav, and a standalone `/dashboard/support` page.

**Error boundaries** (none existed before)
- Accessible `SupportErrorFallback` (recovery action + "Contact support" link, no infinite-retry trap).
- Each of the 5 AI Coach tabs + `ApplicationAIAnalysis` wrapped; route-level `app/(app)/error.tsx` and last-resort `app/global-error.tsx`.

**Analytics**: `ai_chat_retry_clicked`, `support_form_opened/submitted/failed`, `error_boundary_triggered`.

## Tests

New tests for: retry fix (4), email helpers + `replyTo` (9), support route (14 — 401/400/429/200/escaping/reply-to), support form (10), nav entry (2), error-boundary fallback (4). All passing. `tsc` clean on all touched/new files.

## Notes

- Lint/format gates skipped — ESLint isn't installed in the dev env (`next lint` errors) and no Prettier/Biome is configured.
- Follow-ups (not in this PR): wire PostHog **sourcemap upload** into the Vercel build (why this resolved only to `$`), and delete stale `.claude/worktrees/` dirs that pollute `pnpm test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support request form, dedicated support page, and dialog for submitting tickets (with optional contextual error info)
  * "Contact support" added to desktop and mobile navigation

* **Bug Fixes**
  * Fixed AI Coach "Retry" behavior to properly retry and clear errors

* **Improvements**
  * Per-user rate limiting for support requests
  * Expanded error boundaries and global error UI

* **Tests**
  * Comprehensive test coverage for support flows, error fallback, and retry analytics

* **Documentation**
  * Incident report for AI Coach retry issue

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jlamoreaux/apptrack/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->