### PR TITLE
fix: trial subscriptions count as entitled + AI chat validation redesign

### DIFF
--- a/__tests__/api/career-advice-validation.test.ts
+++ b/__tests__/api/career-advice-validation.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for the AI Coach career-advice message content validator.
+ * Focuses on the redesigned diversity check and stable rejection reason codes.
+ */
+
+import {
+  validateMessageContent,
+  type MessageRejectionReason,
+} from "@/app/api/ai-coach/career-advice/route";
+
+// The route module pulls in heavy AI/Supabase deps at import time; stub them so the
+// pure validator can be imported and unit-tested in isolation.
+jest.mock("@/lib/supabase/server");
+jest.mock("@/lib/ai-coach");
+jest.mock("@/lib/middleware/permissions");
+jest.mock("@/lib/middleware/rate-limit.middleware", () => ({
+  withRateLimit: async (handler: any, options: any) => handler(options.request),
+  getUserSubscriptionTier: jest.fn().mockResolvedValue("pro"),
+}));
+jest.mock("@/lib/services/rate-limit.service", () => ({
+  RateLimitService: { getInstance: jest.fn().mockReturnValue({}) },
+}));
+jest.mock("ai", () => ({
+  streamText: jest.fn(),
+  generateText: jest.fn(),
+  tool: jest.fn().mockImplementation((config: any) => config),
+  stepCountIs: jest.fn().mockReturnValue(true),
+}));
+jest.mock("@ai-sdk/openai", () => ({ openai: jest.fn().mockReturnValue("mock-model") }));
+jest.mock("@/services/resumes", () => ({ ResumeService: jest.fn().mockImplementation(() => ({})) }));
+jest.mock("@/dal/applications", () => ({ ApplicationDAL: jest.fn().mockImplementation(() => ({})) }));
+jest.mock("@/lib/analytics/posthog-server", () => ({ captureServerEvent: jest.fn() }));
+
+describe("validateMessageContent", () => {
+  describe("valid messages", () => {
+    const validMessages: Array<[string, string]> = [
+      [
+        "worked example",
+        "I have 5 years in marketing and want to move into product management — what should I focus on?",
+      ],
+      ["normal ~300-char paragraph", buildParagraph()],
+      ["three distinct repeated words", "ok ok ok ok ok ok ok ok"],
+      [
+        "pasted job description with separators",
+        "Responsibilities include the following key areas:\n------------------------\nBuild scalable services and own delivery end to end.\n........................\nCollaborate with product and design partners daily.",
+      ],
+      [
+        "short code snippet",
+        "function add(a, b) {\n  return a + b;\n}\nconsole.log(add(2, 3));",
+      ],
+      [
+        "emoji/CJM content over 30 chars",
+        "Here is my plan for the week 🚀🎯 私は仕事を探しています 頑張ります today",
+      ],
+    ];
+
+    it.each(validMessages)("accepts %s", (_label, message) => {
+      const result = validateMessageContent(message);
+      expect(result.valid).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+  });
+
+  describe("rejected messages", () => {
+    const rejectedMessages: Array<[string, string, MessageRejectionReason]> = [
+      ["single repeated char over floor", "a".repeat(40), "low_diversity"],
+      ["two distinct chars repeated", "ab".repeat(30), "low_diversity"],
+      ["empty string", "", "too_short"],
+      ["below min length", "hi", "too_short"],
+      ["over max length", "a".repeat(10001), "too_long"],
+    ];
+
+    it.each(rejectedMessages)("rejects %s with reason %s", (_label, message, expectedReason) => {
+      const result = validateMessageContent(message);
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBe(expectedReason);
+      expect(result.error).toBeTruthy();
+    });
+  });
+
+  it("does not flag a >30-char message with exactly 3 distinct characters", () => {
+    // "abc" repeated stays at 3 distinct chars (the MIN_DISTINCT_CHARS floor).
+    const result = validateMessageContent("abc".repeat(20));
+    expect(result.valid).toBe(true);
+  });
+
+  describe("diversity floor boundary (DIVERSITY_MIN_LENGTH=30, MIN_DISTINCT_CHARS=3)", () => {
+    it("accepts a low-diversity message at exactly the length floor (30 chars)", () => {
+      // length must be strictly greater than 30 to be checked, so 30 passes.
+      expect(validateMessageContent("a".repeat(30)).valid).toBe(true);
+    });
+
+    it("rejects a 2-distinct message just over the length floor (31 chars)", () => {
+      const result = validateMessageContent("ab".repeat(16)); // 32 chars, 2 distinct
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBe("low_diversity");
+    });
+
+    it("counts code points, so a varied multi-script message passes", () => {
+      expect(validateMessageContent("Plan: 私は仕事 🚀 ready to grow my career now").valid).toBe(true);
+    });
+
+    it("rejects a long single repeated CJK glyph (intended anti-spam behavior)", () => {
+      // 2-distinct repeated CJK over the floor is treated as degenerate input;
+      // this is the one accepted false-positive class (auth + rate limits are the real controls).
+      expect(validateMessageContent("好".repeat(40)).reason).toBe("low_diversity");
+    });
+  });
+});
+
+// Builds a realistic ~300-character paragraph of ordinary prose.
+function buildParagraph(): string {
+  const sentence =
+    "Career transitions take time, so focus on transferable skills and build a clear narrative. ";
+  let text = "";
+  while (text.length < 300) {
+    text += sentence;
+  }
+  return text.slice(0, 300);
+}

--- a/__tests__/api/stripe-status-map.test.ts
+++ b/__tests__/api/stripe-status-map.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Tests for mapStripeStatus (Stripe webhook status mapping).
+ *
+ * The mapping must FAIL CLOSED: only Stripe's "active"/"trialing" grant
+ * entitlements downstream, so every non-paying or unknown Stripe status must
+ * map to a non-entitled value ("canceled"). This guards the payment write-path
+ * against silently granting plans to incomplete/unpaid/paused/future statuses.
+ */
+
+// The route module imports heavy server deps at module load; mock them so the
+// pure mapping function can be imported in isolation (mirrors stripe-webhook.test.ts).
+jest.mock('@/lib/stripe');
+jest.mock('@/services/subscriptions');
+jest.mock('@/lib/supabase/server');
+
+import { mapStripeStatus } from '@/app/api/stripe/webhook/route';
+import { isEntitledStatus } from '@/lib/constants/subscription-status';
+
+describe('mapStripeStatus', () => {
+  const cases: Array<[string, 'active' | 'trialing' | 'past_due' | 'canceled']> = [
+    ['active', 'active'],
+    ['trialing', 'trialing'],
+    ['past_due', 'past_due'],
+    ['canceled', 'canceled'],
+    ['incomplete', 'canceled'],
+    ['incomplete_expired', 'canceled'],
+    ['unpaid', 'canceled'],
+    ['paused', 'canceled'],
+    ['some_future_status', 'canceled'],
+  ];
+
+  it.each(cases)('maps Stripe status "%s" -> "%s"', (input, expected) => {
+    expect(mapStripeStatus(input)).toBe(expected);
+  });
+
+  it('never grants entitlements for non-active/non-trialing Stripe statuses', () => {
+    const nonEntitled = [
+      'past_due',
+      'canceled',
+      'incomplete',
+      'incomplete_expired',
+      'unpaid',
+      'paused',
+      'some_future_status',
+    ];
+    for (const status of nonEntitled) {
+      expect(isEntitledStatus(mapStripeStatus(status))).toBe(false);
+    }
+  });
+});

--- a/__tests__/constants/subscription-status.test.ts
+++ b/__tests__/constants/subscription-status.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests for lib/constants/subscription-status.ts
+ * Single source of truth for subscription status values and entitlement checks.
+ */
+
+// @jest-environment node
+
+import {
+  SUBSCRIPTION_STATUSES,
+  ENTITLED_SUBSCRIPTION_STATUSES,
+  isEntitledStatus,
+} from '@/lib/constants/subscription-status';
+
+describe('isEntitledStatus', () => {
+  it('returns true for "active"', () => {
+    expect(isEntitledStatus('active')).toBe(true);
+  });
+
+  it('returns true for "trialing"', () => {
+    expect(isEntitledStatus('trialing')).toBe(true);
+  });
+
+  it('returns false for "past_due"', () => {
+    expect(isEntitledStatus('past_due')).toBe(false);
+  });
+
+  it('returns false for "canceled"', () => {
+    expect(isEntitledStatus('canceled')).toBe(false);
+  });
+
+  it('returns false for "unpaid"', () => {
+    expect(isEntitledStatus('unpaid')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isEntitledStatus('')).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isEntitledStatus(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isEntitledStatus(undefined)).toBe(false);
+  });
+
+  it('returns false for an unknown string', () => {
+    expect(isEntitledStatus('not-a-status')).toBe(false);
+  });
+});
+
+describe('ENTITLED_SUBSCRIPTION_STATUSES', () => {
+  it('is a subset of SUBSCRIPTION_STATUSES', () => {
+    const all = new Set<string>(SUBSCRIPTION_STATUSES);
+    ENTITLED_SUBSCRIPTION_STATUSES.forEach((status) => {
+      expect(all.has(status)).toBe(true);
+    });
+  });
+});

--- a/__tests__/middleware/permissions-entitlement.test.ts
+++ b/__tests__/middleware/permissions-entitlement.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for PermissionMiddleware.getUserPlanInfo entitlement gating.
+ *
+ * The `isActive` field is derived from the subscription status via the shared
+ * `isEntitledStatus` predicate (SSOT). This proves the refactor preserves
+ * behavior: a `trialing` user is granted access the same as `active`, while a
+ * `canceled` user (or no subscription) is denied.
+ *
+ * We mock at `@/lib/supabase/queries` (`getSubscription`) — the cleanest
+ * boundary, matching repo convention (see __tests__/api/resume-management).
+ */
+
+jest.mock("@/lib/supabase/queries", () => ({
+  getSubscription: jest.fn(),
+}));
+
+jest.mock("@/lib/services/logger.service", () => ({
+  loggerService: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+import { PermissionMiddleware } from "@/lib/middleware/permissions";
+import { getSubscription } from "@/lib/supabase/queries";
+import { PLAN_NAMES } from "@/lib/constants/plans";
+
+const mockGetSubscription = getSubscription as jest.MockedFunction<
+  typeof getSubscription
+>;
+
+const USER_ID = "user-123";
+
+function aiCoachSubscription(status: string) {
+  return {
+    status,
+    subscription_plans: { name: PLAN_NAMES.AI_COACH },
+  } as never;
+}
+
+describe("PermissionMiddleware.getUserPlanInfo entitlement gating", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("grants access for an active subscription", async () => {
+    mockGetSubscription.mockResolvedValue(aiCoachSubscription("active"));
+
+    const info = await PermissionMiddleware.getUserPlanInfo(USER_ID);
+
+    expect(info.isActive).toBe(true);
+    expect(info.isAICoach).toBe(true);
+    expect(info.plan).toBe(PLAN_NAMES.AI_COACH);
+  });
+
+  it("grants access for a trialing subscription, same as active", async () => {
+    mockGetSubscription.mockResolvedValue(aiCoachSubscription("trialing"));
+
+    const info = await PermissionMiddleware.getUserPlanInfo(USER_ID);
+
+    expect(info.isActive).toBe(true);
+    expect(info.isAICoach).toBe(true);
+  });
+
+  it("denies access for a canceled subscription", async () => {
+    mockGetSubscription.mockResolvedValue(aiCoachSubscription("canceled"));
+
+    const info = await PermissionMiddleware.getUserPlanInfo(USER_ID);
+
+    expect(info.isActive).toBe(false);
+  });
+
+  it("denies access for a past_due subscription", async () => {
+    mockGetSubscription.mockResolvedValue(aiCoachSubscription("past_due"));
+
+    const info = await PermissionMiddleware.getUserPlanInfo(USER_ID);
+
+    expect(info.isActive).toBe(false);
+  });
+
+  it("denies access (Free) when there is no subscription", async () => {
+    mockGetSubscription.mockResolvedValue(null);
+
+    const info = await PermissionMiddleware.getUserPlanInfo(USER_ID);
+
+    expect(info.isActive).toBe(false);
+    expect(info.plan).toBe(PLAN_NAMES.FREE);
+    expect(info.isFree).toBe(true);
+  });
+});

--- a/__tests__/services/subscription-status.test.ts
+++ b/__tests__/services/subscription-status.test.ts
@@ -23,14 +23,16 @@ type SingleResult = { data: unknown; error: unknown };
 
 /**
  * Builds a chainable Supabase client stub whose `user_subscriptions` query
- * terminates with the provided `.single()` result. Records the value passed
- * to `.in("status", ...)` so the test can assert the entitled-status filter.
+ * terminates with the provided result. Supports both `.single()` and
+ * `.maybeSingle()` terminals (the DAL uses `.maybeSingle()`). Records the value
+ * passed to `.in("status", ...)` so the test can assert the entitled-status filter.
  */
 function buildSupabaseMock(singleResult: SingleResult) {
   const inArgs: { column: string; values: unknown }[] = [];
 
   const single = jest.fn().mockResolvedValue(singleResult);
-  const limit = jest.fn().mockReturnValue({ single });
+  const maybeSingle = jest.fn().mockResolvedValue(singleResult);
+  const limit = jest.fn().mockReturnValue({ single, maybeSingle });
   const order = jest.fn().mockReturnValue({ limit });
   const inFn = jest.fn().mockImplementation((column: string, values: unknown) => {
     inArgs.push({ column, values });
@@ -40,7 +42,7 @@ function buildSupabaseMock(singleResult: SingleResult) {
   const select = jest.fn().mockReturnValue({ eq });
   const from = jest.fn().mockReturnValue({ select });
 
-  return { supabase: { from }, inArgs, single };
+  return { supabase: { from }, inArgs, single, maybeSingle };
 }
 
 const USER_ID = "user-123";
@@ -79,7 +81,7 @@ describe("SubscriptionService entitlement resolution", () => {
 
   it("falls back to Free / inactive for a canceled subscription (excluded by the entitled filter)", async () => {
     // A canceled row is excluded by `.in([active, trialing])`, so the DAL sees
-    // no matching row and (via maybeSingle/single PGRST116) returns null.
+    // no matching row and (via maybeSingle returning null) resolves to null.
     const { supabase } = buildSupabaseMock({ data: null, error: null });
 
     const service = new SubscriptionService(supabase as never);

--- a/__tests__/services/subscription-status.test.ts
+++ b/__tests__/services/subscription-status.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for SubscriptionService entitlement resolution.
+ *
+ * Exercises getSubscriptionStatus / getUserPlan against a mocked Supabase
+ * query-builder injected into the service constructor. The DAL query under
+ * test is:
+ *   from("user_subscriptions")
+ *     .select("*, subscription_plans!inner(name)")
+ *     .eq("user_id", ...)
+ *     .in("status", ENTITLED_SUBSCRIPTION_STATUSES)
+ *     .order("created_at", { ascending: false })
+ *     .limit(1)
+ *     .single()
+ *
+ * The `.in([active, trialing])` filter means a canceled-only user never
+ * matches a row, so the DAL returns null and the service falls back to "Free".
+ */
+
+import { SubscriptionService } from "@/services/subscriptions";
+import { PLAN_NAMES } from "@/lib/constants/plans";
+
+type SingleResult = { data: unknown; error: unknown };
+
+/**
+ * Builds a chainable Supabase client stub whose `user_subscriptions` query
+ * terminates with the provided `.single()` result. Records the value passed
+ * to `.in("status", ...)` so the test can assert the entitled-status filter.
+ */
+function buildSupabaseMock(singleResult: SingleResult) {
+  const inArgs: { column: string; values: unknown }[] = [];
+
+  const single = jest.fn().mockResolvedValue(singleResult);
+  const limit = jest.fn().mockReturnValue({ single });
+  const order = jest.fn().mockReturnValue({ limit });
+  const inFn = jest.fn().mockImplementation((column: string, values: unknown) => {
+    inArgs.push({ column, values });
+    return { order };
+  });
+  const eq = jest.fn().mockReturnValue({ in: inFn });
+  const select = jest.fn().mockReturnValue({ eq });
+  const from = jest.fn().mockReturnValue({ select });
+
+  return { supabase: { from }, inArgs, single };
+}
+
+const USER_ID = "user-123";
+
+describe("SubscriptionService entitlement resolution", () => {
+  it("resolves a trialing AI Coach subscription as active on the AI Coach plan", async () => {
+    const { supabase, inArgs } = buildSupabaseMock({
+      data: {
+        id: "sub-1",
+        user_id: USER_ID,
+        status: "trialing",
+        created_at: "2026-05-01T00:00:00Z",
+        subscription_plans: { name: "AI Coach" },
+      },
+      error: null,
+    });
+
+    const service = new SubscriptionService(supabase as never);
+
+    const status = await service.getSubscriptionStatus(USER_ID);
+    expect(status).toEqual({
+      plan: "AI Coach",
+      status: "trialing",
+      isActive: true,
+    });
+
+    const plan = await service.getUserPlan(USER_ID);
+    expect(plan).toBe("AI Coach");
+
+    // The query must filter on the entitled statuses, not just "active".
+    expect(inArgs[0]).toEqual({
+      column: "status",
+      values: ["active", "trialing"],
+    });
+  });
+
+  it("falls back to Free / inactive for a canceled subscription (excluded by the entitled filter)", async () => {
+    // A canceled row is excluded by `.in([active, trialing])`, so the DAL sees
+    // no matching row and (via maybeSingle/single PGRST116) returns null.
+    const { supabase } = buildSupabaseMock({ data: null, error: null });
+
+    const service = new SubscriptionService(supabase as never);
+
+    const status = await service.getSubscriptionStatus(USER_ID);
+    expect(status).toEqual({
+      plan: PLAN_NAMES.FREE,
+      status: "none",
+      isActive: false,
+    });
+
+    const plan = await service.getUserPlan(USER_ID);
+    expect(plan).toBe(PLAN_NAMES.FREE);
+  });
+
+  it("does not throw when both an active and a trialing row exist; returns the most recent (order desc)", async () => {
+    // The DB query orders by created_at desc and limits to 1, so the most
+    // recent entitled row wins. Here the trialing AI Coach row is newest.
+    const { supabase } = buildSupabaseMock({
+      data: {
+        id: "sub-trialing-newest",
+        user_id: USER_ID,
+        status: "trialing",
+        created_at: "2026-05-20T00:00:00Z",
+        subscription_plans: { name: "AI Coach" },
+      },
+      error: null,
+    });
+
+    const service = new SubscriptionService(supabase as never);
+
+    await expect(service.getSubscriptionStatus(USER_ID)).resolves.toEqual({
+      plan: "AI Coach",
+      status: "trialing",
+      isActive: true,
+    });
+  });
+});

--- a/app/api/ai-coach/career-advice/route.ts
+++ b/app/api/ai-coach/career-advice/route.ts
@@ -1,4 +1,4 @@
-import { type NextRequest } from "next/server";
+import { type NextRequest, after } from "next/server";
 import { streamText, generateText, tool, stepCountIs, type LanguageModel } from "ai";
 import { openai } from "@ai-sdk/openai";
 import { z } from "zod";
@@ -13,6 +13,7 @@ import { getUserSubscriptionTier } from "@/lib/middleware/rate-limit.middleware"
 import { ResumeService } from "@/services/resumes";
 import { ApplicationDAL } from "@/dal/applications";
 import { APPLICATION_STATUS_VALUES, type ApplicationStatus } from "@/lib/constants/application-status";
+import { captureServerEvent } from "@/lib/analytics/posthog-server";
 
 // Cast to LanguageModel to handle type compatibility between ai and @ai-sdk/openai
 const model = openai("gpt-4o-mini") as LanguageModel;
@@ -444,34 +445,64 @@ const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
 const MAX_MESSAGE_LENGTH = 10000;
 const MIN_MESSAGE_LENGTH = 3;
 
+// Flag only degenerate input with 2 or fewer distinct characters (e.g. "aaaa", "abab").
+const MIN_DISTINCT_CHARS = 3;
+// Absolute length floor below which diversity is not checked — short messages are
+// legitimately low-diversity. This is a fixed threshold, not a length-saturating ratio.
+const DIVERSITY_MIN_LENGTH = 30;
+
+/** Stable reason codes for a rejected message, for observability without string drift. */
+export type MessageRejectionReason = "too_short" | "too_long" | "low_diversity";
+
+export interface MessageValidationResult {
+  valid: boolean;
+  error?: string;
+  reason?: MessageRejectionReason;
+}
+
+/**
+ * Detects degenerate, repeated-character input (e.g. "aaaaaa", "ababab") that carries
+ * no real content. Counts distinct code points and length from the same code-point
+ * array so emoji/CJK surrogate pairs count as one character.
+ */
+function hasInsufficientCharacterDiversity(text: string): boolean {
+  const chars = [...text.replace(/\s+/g, "")];
+  const distinct = new Set(chars).size;
+  const length = chars.length;
+  return length > DIVERSITY_MIN_LENGTH && distinct < MIN_DISTINCT_CHARS;
+}
+
 /**
  * Validates message content for quality and security.
  */
-function validateMessageContent(content: string): { valid: boolean; error?: string } {
+export function validateMessageContent(content: string): MessageValidationResult {
   const trimmed = content.trim();
 
   if (!trimmed) {
-    return { valid: false, error: "Message cannot be empty" };
+    return { valid: false, error: "Message cannot be empty", reason: "too_short" };
   }
 
   if (trimmed.length < MIN_MESSAGE_LENGTH) {
-    return { valid: false, error: "Message is too short. Please provide more context." };
+    return {
+      valid: false,
+      error: "Message is too short. Please provide more context.",
+      reason: "too_short",
+    };
   }
 
   if (trimmed.length > MAX_MESSAGE_LENGTH) {
     return {
       valid: false,
       error: `Message exceeds maximum length of ${MAX_MESSAGE_LENGTH} characters`,
+      reason: "too_long",
     };
   }
 
-  // Check for suspicious patterns
-  const uniqueChars = new Set(trimmed.toLowerCase().replace(/\s/g, "")).size;
-  const totalChars = trimmed.replace(/\s/g, "").length;
-  if (totalChars > 20 && uniqueChars / totalChars < 0.3) {
+  if (hasInsufficientCharacterDiversity(trimmed)) {
     return {
       valid: false,
-      error: "Message appears to contain suspicious patterns. Please use normal text.",
+      error: "Your message looks like repeated characters — please rephrase as normal text.",
+      reason: "low_diversity",
     };
   }
 
@@ -658,6 +689,21 @@ async function careerAdviceHandler(request: NextRequest): Promise<Response> {
     // Validate only the new user message with comprehensive checks (length, spam detection, etc.)
     const lastMessageValidation = validateMessageContent(lastUserContent);
     if (!lastMessageValidation.valid) {
+      // Observe blocked messages without logging raw content (PII): only reason + length.
+      loggerService.warn("AI chat message blocked", {
+        category: LogCategory.BUSINESS,
+        userId: user.id,
+        action: "ai_chat_message_blocked",
+        metadata: {
+          reason: lastMessageValidation.reason,
+          length: lastUserContent.length,
+        },
+      });
+      after(() =>
+        captureServerEvent(user.id, "ai_chat_message_blocked", {
+          reason: lastMessageValidation.reason,
+        })
+      );
       return new Response(
         JSON.stringify({ error: lastMessageValidation.error || "Invalid message" }),
         {

--- a/app/api/stripe/apply-free-code/route.ts
+++ b/app/api/stripe/apply-free-code/route.ts
@@ -3,6 +3,7 @@ import { stripe } from "@/lib/stripe";
 import { createClient, getUser } from "@/lib/supabase/server";
 import { loggerService } from "@/lib/services/logger.service";
 import { LogCategory } from "@/lib/services/logger.types";
+import { ENTITLED_SUBSCRIPTION_STATUSES } from "@/lib/constants/subscription-status";
 
 export async function POST(request: NextRequest) {
   const startTime = Date.now();
@@ -127,13 +128,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Get current subscription
+    // Get current subscription (active or trialing)
     const { data: subscription } = await supabase
       .from("user_subscriptions")
       .select("*, subscription_plans(*)")
       .eq("user_id", user.id)
-      .eq("status", "active")
-      .single();
+      .in("status", [...ENTITLED_SUBSCRIPTION_STATUSES])
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
 
     // If user has an active paid subscription, cancel it
     if (subscription?.stripe_subscription_id) {

--- a/app/api/stripe/apply-free-code/route.ts
+++ b/app/api/stripe/apply-free-code/route.ts
@@ -7,10 +7,12 @@ import { ENTITLED_SUBSCRIPTION_STATUSES } from "@/lib/constants/subscription-sta
 
 export async function POST(request: NextRequest) {
   const startTime = Date.now();
-  
+  // Declared in function scope so the catch block can log it safely.
+  let user: Awaited<ReturnType<typeof getUser>> = null;
+
   try {
-    const user = await getUser();
-    
+    user = await getUser();
+
     if (!user) {
       loggerService.warn('Unauthorized free code application', {
         category: LogCategory.SECURITY,

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -10,6 +10,7 @@ import { loggerService } from "@/lib/services/logger.service";
 import { LogCategory } from "@/lib/services/logger.types";
 import { transitionAudience } from "@/lib/email/drip-scheduler";
 import { captureServerEvent } from "@/lib/analytics/posthog-server";
+import type { SubscriptionStatus } from "@/lib/constants/subscription-status";
 
 const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET!;
 
@@ -129,24 +130,30 @@ export async function POST(request: NextRequest) {
   }
 }
 
-// Helper function to map Stripe status to our database status
-function mapStripeStatus(
-  stripeStatus: string
-): "active" | "canceled" | "past_due" | "trialing" {
+// Helper function to map Stripe status to our database status.
+// Exported for unit testing (see __tests__/api/stripe-status-map.test.ts).
+export function mapStripeStatus(stripeStatus: string): SubscriptionStatus {
   switch (stripeStatus) {
     case "active":
       return "active";
-    case "canceled":
-      return "canceled";
-    case "past_due":
-      return "past_due";
     case "trialing":
       return "trialing";
+    case "past_due":
+      return "past_due";
+    case "canceled":
+      return "canceled";
+    // Non-entitled Stripe states map to "canceled" so they never grant the plan.
     case "incomplete":
     case "incomplete_expired":
     case "unpaid":
+    case "paused":
+      return "canceled";
     default:
-      return "trialing"; // Default to trialing for any unknown or pending states
+      // Fail closed: an unknown/future Stripe status must not silently grant
+      // entitlements. Real trials always arrive as the explicit "trialing"
+      // case above, and a paid signup briefly in "incomplete" transitions to
+      // "active" via a later subscription.updated webhook that overwrites this.
+      return "canceled";
   }
 }
 

--- a/components/danger-zone.tsx
+++ b/components/danger-zone.tsx
@@ -24,6 +24,7 @@ import {
 import { deleteAccountAction } from "@/lib/actions";
 import { useFeatureFlag, FEATURE_FLAGS } from "@/lib/hooks/use-feature-flag";
 import type { UserSubscription } from "@/lib/supabase";
+import { isEntitledStatus } from "@/lib/constants/subscription-status";
 
 interface DangerZoneProps {
   userId: string;
@@ -57,7 +58,7 @@ export function DangerZone({ userId, subscription }: DangerZoneProps) {
 
   const isOnPaidPlan =
     subscription?.subscription_plans?.name !== "Free" &&
-    subscription?.status === "active";
+    isEntitledStatus(subscription?.status);
   const confirmationText = "DELETE MY ACCOUNT";
   const isAuditEnabled = useFeatureFlag(FEATURE_FLAGS.DASHBOARD_UX_AUDIT);
 

--- a/components/subscription-management.tsx
+++ b/components/subscription-management.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { formatLocalDate } from "@/lib/utils/date";
 import { useFeatureFlag, FEATURE_FLAGS } from "@/lib/hooks/use-feature-flag";
+import { isEntitledStatus } from "@/lib/constants/subscription-status";
 
 interface SubscriptionManagementProps {
   userId: string;
@@ -46,7 +47,7 @@ export function SubscriptionManagement({
 
   const isOnFreePlan =
     subscription?.subscription_plans?.name === "Free" || !subscription;
-  const isActive = subscription?.status === "active";
+  const isActive = isEntitledStatus(subscription?.status);
 
   const handleCancelSubscription = async () => {
     if (!subscription || !subscription.stripe_subscription_id) return;

--- a/dal/subscriptions/index.ts
+++ b/dal/subscriptions/index.ts
@@ -270,18 +270,16 @@ export class SubscriptionDAL
         .in("status", [...ENTITLED_SUBSCRIPTION_STATUSES])
         .order("created_at", { ascending: false })
         .limit(1)
-        .single();
+        .maybeSingle();
 
       if (error) {
-        if (error.code === "PGRST116") {
-          return null; // Not found
-        }
         throw new DALError(
           `Failed to get current subscription: ${error.message}`,
           "QUERY_ERROR"
         );
       }
 
+      // maybeSingle returns null when no entitled subscription exists.
       return data;
     } catch (error) {
       if (error instanceof DALError) throw error;
@@ -444,12 +442,9 @@ export class SubscriptionDAL
         .in("status", [...ENTITLED_SUBSCRIPTION_STATUSES])
         .order("created_at", { ascending: false })
         .limit(1)
-        .single();
+        .maybeSingle();
 
       if (error) {
-        if (error.code === "PGRST116") {
-          return null; // Not found
-        }
         throw new DALError(
           `Failed to get subscription with plan name: ${error.message}`,
           "QUERY_ERROR"

--- a/dal/subscriptions/index.ts
+++ b/dal/subscriptions/index.ts
@@ -2,13 +2,17 @@ import { createClient } from "@/lib/supabase/server";
 import { BaseDAL, DALError, NotFoundError, ValidationError } from "../base";
 import type { Subscription } from "@/types";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  ENTITLED_SUBSCRIPTION_STATUSES,
+  type SubscriptionStatus,
+} from "@/lib/constants/subscription-status";
 
 export interface CreateSubscriptionInput {
   user_id: string;
   plan_id: string;
   stripe_customer_id?: string;
   stripe_subscription_id?: string;
-  status: "active" | "canceled" | "past_due" | "unpaid" | "trialing";
+  status: SubscriptionStatus;
   billing_cycle: "monthly" | "yearly";
   current_period_start: string;
   current_period_end: string;
@@ -19,7 +23,7 @@ export interface UpdateSubscriptionInput {
   plan_id?: string;
   stripe_customer_id?: string;
   stripe_subscription_id?: string;
-  status?: "active" | "canceled" | "past_due" | "unpaid" | "trialing";
+  status?: SubscriptionStatus;
   billing_cycle?: "monthly" | "yearly";
   current_period_start?: string;
   current_period_end?: string;
@@ -232,19 +236,19 @@ export class SubscriptionDAL
         .from("user_subscriptions")
         .select("*")
         .eq("user_id", userId)
-        .eq("status", "active")
-        .single();
+        .in("status", [...ENTITLED_SUBSCRIPTION_STATUSES])
+        .order("created_at", { ascending: false })
+        .limit(1)
+        .maybeSingle();
 
       if (error) {
-        if (error.code === "PGRST116") {
-          return null; // Not found
-        }
         throw new DALError(
           `Failed to get active subscription: ${error.message}`,
           "QUERY_ERROR"
         );
       }
 
+      // maybeSingle returns null when no entitled subscription exists.
       return data;
     } catch (error) {
       if (error instanceof DALError) throw error;
@@ -263,7 +267,7 @@ export class SubscriptionDAL
         .from("user_subscriptions")
         .select("*")
         .eq("user_id", userId)
-        .in("status", ["active", "trialing"])
+        .in("status", [...ENTITLED_SUBSCRIPTION_STATUSES])
         .order("created_at", { ascending: false })
         .limit(1)
         .single();
@@ -437,7 +441,7 @@ export class SubscriptionDAL
         `
         )
         .eq("user_id", userId)
-        .eq("status", "active")
+        .in("status", [...ENTITLED_SUBSCRIPTION_STATUSES])
         .order("created_at", { ascending: false })
         .limit(1)
         .single();

--- a/lib/actions/account.ts
+++ b/lib/actions/account.ts
@@ -5,6 +5,7 @@ import { createAdminClient } from "../supabase/admin-client";
 import { revalidatePath } from "next/cache";
 import { stripe } from "../stripe";
 import { AuditAction, EntityType } from "../services/audit.service";
+import { ENTITLED_SUBSCRIPTION_STATUSES } from "@/lib/constants/subscription-status";
 
 export async function deleteAccountAction(formData: FormData) {
   try {
@@ -28,13 +29,15 @@ export async function deleteAccountAction(formData: FormData) {
     const userEmail = profile?.email || user.email || "unknown";
     const userName = profile?.full_name || "unknown";
 
-    // Get user's subscription to cancel it
+    // Get user's subscription to cancel it (active or trialing)
     const { data: subscription } = await supabase
       .from("user_subscriptions")
       .select("stripe_subscription_id")
       .eq("user_id", user.id)
-      .eq("status", "active")
-      .single();
+      .in("status", [...ENTITLED_SUBSCRIPTION_STATUSES])
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
 
     // Cancel Stripe subscription if it exists
     if (subscription?.stripe_subscription_id) {

--- a/lib/constants/subscription-status.ts
+++ b/lib/constants/subscription-status.ts
@@ -1,0 +1,31 @@
+// Single source of truth for subscription status values.
+// ZERO-IMPORT leaf module: imported by client components (e.g. components/danger-zone.tsx),
+// so it must not import anything (especially server-only modules).
+
+// The statuses our Stripe webhook (mapStripeStatus) can actually persist.
+// Note: "unpaid" is intentionally excluded — mapStripeStatus never emits it.
+export const SUBSCRIPTION_STATUSES = [
+  "active",
+  "trialing",
+  "past_due",
+  "canceled",
+] as const;
+
+export type SubscriptionStatus = (typeof SUBSCRIPTION_STATUSES)[number];
+
+// Statuses where the user currently holds their plan entitlements.
+export const ENTITLED_SUBSCRIPTION_STATUSES = [
+  "active",
+  "trialing",
+] as const satisfies readonly SubscriptionStatus[];
+
+/**
+ * Returns true iff the status grants plan entitlements — i.e. the user
+ * currently has the plan (active subscription or in trial). Total: any
+ * null/undefined/unknown value returns false.
+ */
+export function isEntitledStatus(status: string | null | undefined): boolean {
+  return (ENTITLED_SUBSCRIPTION_STATUSES as readonly string[]).includes(
+    status ?? ""
+  );
+}

--- a/lib/middleware/permissions.ts
+++ b/lib/middleware/permissions.ts
@@ -5,6 +5,7 @@ import {
   canAccessFeature,
 } from "@/lib/constants/permissions";
 import { PLAN_NAMES } from "@/lib/constants/plans";
+import { isEntitledStatus } from "@/lib/constants/subscription-status";
 import { PermissionServiceError } from "@/services/base";
 import {
   isOnProOrHigher,
@@ -215,9 +216,7 @@ export class PermissionMiddleware {
       const subscription = await getSubscription(userId);
       const plan = subscription?.subscription_plans?.name || PLAN_NAMES.FREE;
       const status = subscription?.status || "none";
-      const isActive =
-        subscription?.status === "active" ||
-        subscription?.status === "trialing";
+      const isActive = isEntitledStatus(subscription?.status);
       const isAICoach = isOnAICoachPlan(plan);
       const isPro = isOnProOrHigher(plan);
       const isFree = isOnFreePlan(plan);

--- a/lib/middleware/rate-limit.middleware.ts
+++ b/lib/middleware/rate-limit.middleware.ts
@@ -6,6 +6,7 @@ import {
 } from "@/lib/services/rate-limit.service";
 import { loggerService } from "@/lib/services/logger.service";
 import { LogCategory } from "@/lib/services/logger.types";
+import { ENTITLED_SUBSCRIPTION_STATUSES } from "@/lib/constants/subscription-status";
 
 export interface RateLimitOptions {
   feature: AIFeature;
@@ -50,7 +51,7 @@ export async function withRateLimit(
       .from("user_subscriptions")
       .select("subscription_plans(name)")
       .eq("user_id", user.id)
-      .in("status", ["active", "trialing"])
+      .in("status", [...ENTITLED_SUBSCRIPTION_STATUSES])
       .order("created_at", { ascending: false })
       .limit(1)
       .maybeSingle();
@@ -190,7 +191,7 @@ export async function getUserSubscriptionTier(
       .from("user_subscriptions")
       .select("subscription_plans(name)")
       .eq("user_id", userId)
-      .in("status", ["active", "trialing"])
+      .in("status", [...ENTITLED_SUBSCRIPTION_STATUSES])
       .order("created_at", { ascending: false })
       .limit(1)
       .maybeSingle();

--- a/lib/roast/rate-limiter.ts
+++ b/lib/roast/rate-limiter.ts
@@ -1,27 +1,16 @@
 import { createClient } from "@/lib/supabase/server";
 import { ROAST_CONSTANTS } from "@/lib/constants/roast";
-import { ENTITLED_SUBSCRIPTION_STATUSES } from "@/lib/constants/subscription-status";
+// Reuse the canonical tier resolver instead of duplicating it. The previous
+// local copy queried a non-existent `user_subscriptions.subscription_tier`
+// column, so it always returned 'free'; the shared helper derives the tier from
+// the joined plan name.
+import { getUserSubscriptionTier } from "@/lib/middleware/rate-limit.middleware";
 
 interface RateLimitResult {
   allowed: boolean;
   remaining: number;
   resetAt: Date;
   limit: number;
-}
-
-async function getUserSubscriptionTier(userId: string): Promise<'free' | 'pro' | 'ai_coach'> {
-  const supabase = await createClient();
-  
-  const { data: subscription } = await supabase
-    .from("user_subscriptions")
-    .select("subscription_tier")
-    .eq("user_id", userId)
-    .in("status", [...ENTITLED_SUBSCRIPTION_STATUSES])
-    .order("created_at", { ascending: false })
-    .limit(1)
-    .maybeSingle();
-
-  return subscription?.subscription_tier || 'free';
 }
 
 export async function checkRoastRateLimit(userId: string, version?: string): Promise<RateLimitResult> {

--- a/lib/roast/rate-limiter.ts
+++ b/lib/roast/rate-limiter.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { ROAST_CONSTANTS } from "@/lib/constants/roast";
+import { ENTITLED_SUBSCRIPTION_STATUSES } from "@/lib/constants/subscription-status";
 
 interface RateLimitResult {
   allowed: boolean;
@@ -15,9 +16,11 @@ async function getUserSubscriptionTier(userId: string): Promise<'free' | 'pro' |
     .from("user_subscriptions")
     .select("subscription_tier")
     .eq("user_id", userId)
-    .eq("status", "active")
-    .single();
-    
+    .in("status", [...ENTITLED_SUBSCRIPTION_STATUSES])
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
   return subscription?.subscription_tier || 'free';
 }
 

--- a/lib/services/admin.service.ts
+++ b/lib/services/admin.service.ts
@@ -1,4 +1,5 @@
 import { UsersDAL, type UserWithSubscription } from "@/lib/dal/users.dal";
+import { isEntitledStatus } from "@/lib/constants/subscription-status";
 
 /**
  * Admin service for managing admin users and permissions
@@ -63,7 +64,7 @@ export class AdminService {
       // Map the data to include admin status and format subscription info
       const mappedUsers = users.map(user => {
         const activeSubscription = user.user_subscriptions?.find(
-          sub => sub.status === 'active' || sub.status === 'trialing'
+          sub => isEntitledStatus(sub.status)
         );
 
         return {

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -1,4 +1,6 @@
 // Types for our database
+import type { SubscriptionStatus } from "@/lib/constants/subscription-status";
+
 export interface Profile {
   id: string;
   email: string;
@@ -64,7 +66,7 @@ export interface UserSubscription {
   id: string;
   user_id: string;
   plan_id: string;
-  status: "active" | "canceled" | "past_due" | "trialing";
+  status: SubscriptionStatus;
   billing_cycle: "monthly" | "yearly";
   current_period_start: string;
   current_period_end: string;

--- a/services/subscriptions/index.ts
+++ b/services/subscriptions/index.ts
@@ -12,6 +12,7 @@ import {
 } from "@/dal/subscriptions";
 import type { Subscription } from "@/types";
 import { PLAN_NAMES } from "@/lib/constants/plans";
+import { isEntitledStatus } from "@/lib/constants/subscription-status";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { loggerService } from "@/lib/services/logger.service";
 import { LogCategory } from "@/lib/services/logger.types";
@@ -388,9 +389,7 @@ export class SubscriptionService
   async isSubscriptionActive(userId: string): Promise<boolean> {
     try {
       const subscription = await this.getCurrentSubscription(userId);
-      return (
-        subscription?.status === "active" || subscription?.status === "trialing"
-      );
+      return isEntitledStatus(subscription?.status);
     } catch (error) {
       throw wrapDALError(error, "Failed to check if subscription is active");
     }
@@ -404,9 +403,7 @@ export class SubscriptionService
         await this.subscriptionDAL.getSubscriptionWithPlanName(userId);
       const plan = subscription?.plan_name || PLAN_NAMES.FREE;
       const status = subscription?.status || "none";
-      const isActive =
-        subscription?.status === "active" ||
-        subscription?.status === "trialing";
+      const isActive = isEntitledStatus(subscription?.status);
 
       return { plan, status, isActive };
     } catch (error) {

--- a/services/subscriptions/index.ts
+++ b/services/subscriptions/index.ts
@@ -180,7 +180,7 @@ export class SubscriptionService
         );
         
         // Log specific business events for important status changes
-        if (data.status === 'cancelled' || data.status === 'canceled') {
+        if (data.status === 'canceled') {
           loggerService.logBusinessMetric(
             'subscription_cancelled',
             1,

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,5 +1,10 @@
 import type React from "react";
 
+// Single source of truth for the subscription status union.
+// Type-only re-export keeps this free of runtime/client-bundle coupling.
+export type { SubscriptionStatus } from "@/lib/constants/subscription-status";
+import type { SubscriptionStatus } from "@/lib/constants/subscription-status";
+
 // Core application types
 export interface User {
   id: string;
@@ -71,7 +76,7 @@ export interface Subscription {
   plan_id: string;
   stripe_customer_id?: string;
   stripe_subscription_id?: string;
-  status: "active" | "canceled" | "past_due" | "unpaid" | "trialing";
+  status: SubscriptionStatus;
   billing_cycle: "monthly" | "yearly";
   current_period_start: string;
   current_period_end: string;


### PR DESCRIPTION
Fixes two production bugs that hit a real trialing **AI Coach** user (confirmed in PostHog: `checkout_started`/`upgrade_completed` with `has_trial=True, plan="AI Coach"`, then `/dashboard/upgrade` showed "Free"). Both fixed at the root per the "no band-aid" directive.

## Bug 1 — trial users shown as "Free" / treated as not-entitled

**Root cause:** no single source of truth for subscription-status semantics. The status union was declared inline in two disagreeing places, and "entitled = active||trialing" was hand-copied across ~30 sites — several used `active`-only and were silently wrong for trials. The upgrade page's read path (`getSubscriptionWithPlanName`) filtered `.eq("status","active")`, excluding `trialing`.

**Fix:**
- New `lib/constants/subscription-status.ts` (zero-import leaf): `SUBSCRIPTION_STATUSES`, `SubscriptionStatus` type (surfaced via `types/index.ts`, replacing both inline unions), `ENTITLED_SUBSCRIPTION_STATUSES`, `isEntitledStatus()`.
- Every entitlement decision now reads from it: DAL, account deletion, roast tier, free-code, danger-zone, subscription-management, services, permissions, admin, rate-limit middleware.
- Widened `.single()` queries hardened with `order/limit(1)/maybeSingle` so a user with both an active and a trialing row can't throw (which on the cancel paths would have left a Stripe sub uncancelled).

## Bug 2 — fail-closed Stripe status mapping

`mapStripeStatus` defaulted unknown/incomplete/unpaid/paused → `trialing`, silently **granting** entitlements to non-paying states (made worse by widening the read path). Now fails closed to `canceled`; only explicit `active`/`trialing` grant the plan. *(Highest-risk change — payment write-path; please review `mapStripeStatus` closely. Safe because real trials arrive as explicit `trialing` and a paid signup's brief `incomplete` transitions to `active` via `subscription.updated`.)*

## Bug 3 — AI chat "suspicious patterns" false positives + silent blocks

The `uniqueChars/totalChars < 0.3` check saturates and blocks any normal message over ~80-90 chars. Replaced with an absolute, code-point-aware diversity floor (flag only <3 distinct chars over 30 chars; no run-length regex, which false-positives on pasted `----`/`....` separators). Added **block observability** (`loggerService.warn` + `captureServerEvent("ai_chat_message_blocked", { reason })`) — the block was previously silent server-side, which is why this went unmeasured.

## Tests
SSOT predicate; trialing→plan / canceled→Free service resolution incl. dual-row no-throw; permissions grants trialing & denies canceled/past_due; Stripe status mapping table; chat validation pass/reject incl. boundary + multilingual/emoji. Full suite green (81 suites, 1304 passed). `tsc` introduces zero new errors.

## Known trade-offs (logged, not fixed)
- `getSubscriptionWithPlanName` uses `subscription_plans!inner` — a trialing row with an orphaned `plan_id` would drop to Free. `plan_id` is `NOT NULL` FK and the 3 plans are stable, so not reachable in practice.
- Discovered pre-existing (out of scope): `services/subscriptions/index.ts` compares a status to British-spelling `'cancelled'` (dead comparison; our values use `'canceled'`); and `apply-free-code` has a `user`-in-catch scoping bug.

## Follow-up
Watch the new `ai_chat_message_blocked` PostHog event after deploy to confirm the false-positive rate dropped to ~zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for subscription status validation, message content validation, and Stripe status mapping.

* **Bug Fixes**
  * Improved Stripe status mapping to use "fail closed" policy, ensuring non-entitled statuses are safely marked as canceled.

* **Refactor**
  * Centralized subscription status constants and eligibility checks across the application for consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jlamoreaux/apptrack/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->