### PR TITLE
feat: pre-charge trial-ending email for Stripe trials

### DIFF
--- a/__tests__/api/stripe-trial-will-end.test.ts
+++ b/__tests__/api/stripe-trial-will-end.test.ts
@@ -83,8 +83,8 @@ function makeSubscription(
     status: 'trialing',
     cancel_at_period_end: false,
     default_payment_method: null,
-    // ~3 days out so the FIX 3 stale-trial_end guard never trips for the
-    // happy-path tests. The dedicated stale test overrides this with a past value.
+    // ~3 days out so the stale-trial_end guard never trips for the happy-path
+    // tests. The dedicated stale test overrides this with a past value.
     trial_end: Math.floor((Date.now() + 3 * 24 * 60 * 60 * 1000) / 1000),
     metadata: { userId: 'user_abc' },
     items: {
@@ -239,6 +239,18 @@ describe('handleTrialWillEnd', () => {
     const subscriptionService = makeSubscriptionService();
     const sub = makeSubscription();
     (sub.items.data[0].price as any).unit_amount = null;
+
+    await handleTrialWillEnd(sub, subscriptionService as any, makeServiceClient());
+
+    expect(mockSendTrialEndingEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ amountFormatted: undefined })
+    );
+  });
+
+  it('uses generic copy when unit_amount is 0 (no "$0.00 charge" line)', async () => {
+    const subscriptionService = makeSubscriptionService();
+    const sub = makeSubscription();
+    (sub.items.data[0].price as any).unit_amount = 0;
 
     await handleTrialWillEnd(sub, subscriptionService as any, makeServiceClient());
 

--- a/__tests__/api/stripe-trial-will-end.test.ts
+++ b/__tests__/api/stripe-trial-will-end.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Tests for handleTrialWillEnd (Stripe `customer.subscription.trial_will_end`).
+ *
+ * This handler sends a compliance-required pre-charge notice. Behavior under
+ * test: it only emails trials that will actually charge, dedupes via
+ * `trial_ending_notified_at`, stamps that column only after a successful send,
+ * captures the analytics event, and RETHROWS on send failure so Stripe retries.
+ *
+ * The route module imports heavy server deps at load; mock them so the handler
+ * can be imported in isolation (mirrors stripe-status-map.test.ts).
+ */
+
+jest.mock('@/lib/stripe');
+jest.mock('@/services/subscriptions');
+jest.mock('@/lib/supabase/server');
+jest.mock('@/lib/email/transactional');
+jest.mock('@/lib/analytics/posthog-server');
+jest.mock('@/lib/services/logger.service', () => ({
+  loggerService: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// `after` runs its callback synchronously in tests so we can assert captures.
+jest.mock('next/server', () => ({
+  after: (fn: () => unknown) => fn(),
+}));
+
+import type Stripe from 'stripe';
+import { stripe } from '@/lib/stripe';
+import { sendTrialEndingEmail } from '@/lib/email/transactional';
+import { captureServerEvent } from '@/lib/analytics/posthog-server';
+import { handleTrialWillEnd } from '@/app/api/stripe/webhook/route';
+
+const mockStripe = stripe as jest.Mocked<typeof stripe>;
+const mockSendTrialEndingEmail = sendTrialEndingEmail as jest.MockedFunction<
+  typeof sendTrialEndingEmail
+>;
+const mockCaptureServerEvent = captureServerEvent as jest.MockedFunction<
+  typeof captureServerEvent
+>;
+
+type FakeSubscriptionService = {
+  findByStripeSubscriptionId: jest.Mock;
+  updateFromStripeWebhook: jest.Mock;
+};
+
+function makeSubscriptionService(
+  overrides?: Partial<FakeSubscriptionService>
+): FakeSubscriptionService {
+  return {
+    // Default: a local row exists (the idempotency anchor) with no prior
+    // notification. Tests that exercise the missing-row path override this.
+    findByStripeSubscriptionId: jest.fn().mockResolvedValue({
+      user_id: 'user_abc',
+      trial_ending_notified_at: null,
+    }),
+    updateFromStripeWebhook: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+// Service-role client stub: only the plan-name lookup chain is exercised.
+function makeServiceClient(planName: string | null = 'Pro Plan') {
+  const maybeSingle = jest
+    .fn()
+    .mockResolvedValue({ data: planName ? { name: planName } : null, error: null });
+  const or = jest.fn().mockReturnValue({ maybeSingle });
+  const select = jest.fn().mockReturnValue({ or });
+  const from = jest.fn().mockReturnValue({ select });
+  return { from } as any;
+}
+
+function makeSubscription(
+  overrides?: Partial<Stripe.Subscription>
+): Stripe.Subscription {
+  return {
+    id: 'sub_123',
+    customer: 'cus_123',
+    status: 'trialing',
+    cancel_at_period_end: false,
+    default_payment_method: null,
+    // ~3 days out so the FIX 3 stale-trial_end guard never trips for the
+    // happy-path tests. The dedicated stale test overrides this with a past value.
+    trial_end: Math.floor((Date.now() + 3 * 24 * 60 * 60 * 1000) / 1000),
+    metadata: { userId: 'user_abc' },
+    items: {
+      data: [
+        {
+          price: {
+            id: 'price_monthly',
+            unit_amount: 900,
+            currency: 'usd',
+            recurring: { interval: 'month', interval_count: 1 },
+          },
+        },
+      ],
+    },
+    ...overrides,
+  } as unknown as Stripe.Subscription;
+}
+
+function mockCustomer(customer: Record<string, unknown>) {
+  (mockStripe.customers as any) = {
+    retrieve: jest.fn().mockResolvedValue(customer),
+  };
+}
+
+describe('handleTrialWillEnd', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSendTrialEndingEmail.mockResolvedValue({ success: true });
+    mockCaptureServerEvent.mockResolvedValue(undefined);
+    // Default: card on the customer (Checkout trial shape).
+    mockCustomer({
+      email: 'trialer@example.com',
+      invoice_settings: { default_payment_method: 'pm_123' },
+      default_source: null,
+    });
+  });
+
+  it('happy path: sends email, stamps row, captures event', async () => {
+    const subscriptionService = makeSubscriptionService();
+    const serviceClient = makeServiceClient('Pro Plan');
+
+    await handleTrialWillEnd(
+      makeSubscription(),
+      subscriptionService as any,
+      serviceClient
+    );
+
+    expect(mockSendTrialEndingEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'trialer@example.com',
+        planName: 'Pro Plan',
+        amountFormatted: '$9.00',
+        cadence: 'month',
+        manageUrl: expect.stringContaining('/dashboard/settings'),
+      })
+    );
+    expect(subscriptionService.updateFromStripeWebhook).toHaveBeenCalledWith(
+      'sub_123',
+      expect.objectContaining({
+        trial_ending_notified_at: expect.any(String),
+      })
+    );
+    expect(mockCaptureServerEvent).toHaveBeenCalledWith(
+      'user_abc',
+      'trial_ending_notified',
+      expect.objectContaining({
+        subscription_id: 'sub_123',
+        amount_cents: 900,
+        currency: 'usd',
+        interval: 'month',
+      })
+    );
+  });
+
+  it('sends when card is on the customer only (subscription field null)', async () => {
+    mockCustomer({
+      email: 'trialer@example.com',
+      invoice_settings: { default_payment_method: 'pm_cust' },
+      default_source: null,
+    });
+    const subscriptionService = makeSubscriptionService();
+
+    await handleTrialWillEnd(
+      makeSubscription({ default_payment_method: null }),
+      subscriptionService as any,
+      makeServiceClient()
+    );
+
+    expect(mockSendTrialEndingEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('idempotent skip: does nothing when already notified', async () => {
+    const subscriptionService = makeSubscriptionService({
+      findByStripeSubscriptionId: jest.fn().mockResolvedValue({
+        user_id: 'user_abc',
+        trial_ending_notified_at: '2026-01-01T00:00:00.000Z',
+      }),
+    });
+
+    await handleTrialWillEnd(
+      makeSubscription(),
+      subscriptionService as any,
+      makeServiceClient()
+    );
+
+    expect(mockSendTrialEndingEmail).not.toHaveBeenCalled();
+    expect(subscriptionService.updateFromStripeWebhook).not.toHaveBeenCalled();
+  });
+
+  it('skips when cancel_at_period_end is true', async () => {
+    const subscriptionService = makeSubscriptionService();
+
+    await handleTrialWillEnd(
+      makeSubscription({ cancel_at_period_end: true }),
+      subscriptionService as any,
+      makeServiceClient()
+    );
+
+    expect(mockSendTrialEndingEmail).not.toHaveBeenCalled();
+  });
+
+  it('skips when no payment method anywhere', async () => {
+    mockCustomer({
+      email: 'trialer@example.com',
+      invoice_settings: { default_payment_method: null },
+      default_source: null,
+    });
+    const subscriptionService = makeSubscriptionService();
+
+    await handleTrialWillEnd(
+      makeSubscription({ default_payment_method: null }),
+      subscriptionService as any,
+      makeServiceClient()
+    );
+
+    expect(mockSendTrialEndingEmail).not.toHaveBeenCalled();
+  });
+
+  it('skips when trial_end is null', async () => {
+    const subscriptionService = makeSubscriptionService();
+
+    await handleTrialWillEnd(
+      makeSubscription({ trial_end: null }),
+      subscriptionService as any,
+      makeServiceClient()
+    );
+
+    expect(mockSendTrialEndingEmail).not.toHaveBeenCalled();
+  });
+
+  it('uses generic copy (no amount) when unit_amount is null', async () => {
+    const subscriptionService = makeSubscriptionService();
+    const sub = makeSubscription();
+    (sub.items.data[0].price as any).unit_amount = null;
+
+    await handleTrialWillEnd(sub, subscriptionService as any, makeServiceClient());
+
+    expect(mockSendTrialEndingEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ amountFormatted: undefined })
+    );
+  });
+
+  it('rethrows on send failure and does not stamp the row', async () => {
+    mockSendTrialEndingEmail.mockResolvedValue({ success: false });
+    const subscriptionService = makeSubscriptionService();
+
+    await expect(
+      handleTrialWillEnd(
+        makeSubscription(),
+        subscriptionService as any,
+        makeServiceClient()
+      )
+    ).rejects.toThrow();
+
+    expect(subscriptionService.updateFromStripeWebhook).not.toHaveBeenCalled();
+  });
+
+  it('returns without sending when userId cannot be resolved', async () => {
+    const subscriptionService = makeSubscriptionService({
+      findByStripeSubscriptionId: jest.fn().mockResolvedValue(null),
+    });
+    const sub = makeSubscription({ metadata: {} });
+
+    await handleTrialWillEnd(sub, subscriptionService as any, makeServiceClient());
+
+    expect(mockSendTrialEndingEmail).not.toHaveBeenCalled();
+    expect(subscriptionService.updateFromStripeWebhook).not.toHaveBeenCalled();
+  });
+
+  it('does not send when there is no local row, even if metadata has userId', async () => {
+    // Without a local row we cannot stamp trial_ending_notified_at, so sending
+    // would risk a duplicate on Stripe redelivery. Require the row.
+    const subscriptionService = makeSubscriptionService({
+      findByStripeSubscriptionId: jest.fn().mockResolvedValue(null),
+    });
+    // metadata.userId is set, so userId resolves — but local row is null.
+    const sub = makeSubscription({ metadata: { userId: 'user_abc' } });
+
+    await handleTrialWillEnd(sub, subscriptionService as any, makeServiceClient());
+
+    expect(mockSendTrialEndingEmail).not.toHaveBeenCalled();
+    expect(subscriptionService.updateFromStripeWebhook).not.toHaveBeenCalled();
+  });
+
+  it('skips when trial_end is already in the past', async () => {
+    const subscriptionService = makeSubscriptionService();
+    // A trial_end well in the past (e.g. a late/retried event).
+    const pastTrialEnd = Math.floor((Date.now() - 60_000) / 1000);
+
+    await handleTrialWillEnd(
+      makeSubscription({ trial_end: pastTrialEnd }),
+      subscriptionService as any,
+      makeServiceClient()
+    );
+
+    expect(mockSendTrialEndingEmail).not.toHaveBeenCalled();
+    expect(subscriptionService.updateFromStripeWebhook).not.toHaveBeenCalled();
+  });
+
+  it('formats multi-count cadence without "every" (e.g. "3 months")', async () => {
+    const subscriptionService = makeSubscriptionService();
+    const sub = makeSubscription();
+    (sub.items.data[0].price as any).recurring = {
+      interval: 'month',
+      interval_count: 3,
+    };
+
+    await handleTrialWillEnd(sub, subscriptionService as any, makeServiceClient());
+
+    expect(mockSendTrialEndingEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ cadence: '3 months' })
+    );
+  });
+});

--- a/__tests__/email/trial-ending-email.test.ts
+++ b/__tests__/email/trial-ending-email.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for the pre-charge trial-ending email (sendTrialEndingEmail) and the
+ * parameterized wrapEmail footer.
+ *
+ * The Resend client is replaced by mocking `@/lib/email/client`'s `sendEmail`,
+ * so we inspect the exact payload the sender builds.
+ */
+
+// @jest-environment node
+
+const mockSendEmail = jest.fn();
+
+jest.mock('@/lib/email/client', () => ({
+  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
+}));
+
+import {
+  sendTrialEndingEmail,
+  sendRoastReadyEmail,
+} from '@/lib/email/transactional';
+
+type SendEmailArgs = {
+  to: string;
+  subject: string;
+  html: string;
+  replyTo?: string;
+};
+
+/** Read the single argument passed to the mocked sendEmail. */
+function lastSendEmailCall(): SendEmailArgs {
+  return mockSendEmail.mock.calls.at(-1)![0] as SendEmailArgs;
+}
+
+const BASE_OPTIONS = {
+  email: 'user@example.com',
+  firstName: 'Jordan',
+  planName: 'AppTrack Pro',
+  amountFormatted: '$9.00',
+  cadence: 'month',
+  trialEndDate: 'June 5, 2026',
+  manageUrl: 'https://www.apptrack.ing/dashboard/settings',
+};
+
+// Matches the emoji ranges that would appear in marketing-style copy.
+const EMOJI_REGEX =
+  /[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}\u{2190}-\u{21FF}\u{2B00}-\u{2BFF}\u{FE0F}]/u;
+
+describe('sendTrialEndingEmail', () => {
+  beforeEach(() => {
+    mockSendEmail.mockReset();
+    mockSendEmail.mockResolvedValue({ success: true });
+  });
+
+  it('sends to the user with replyTo support@apptrack.ing', async () => {
+    await sendTrialEndingEmail(BASE_OPTIONS);
+
+    const call = lastSendEmailCall();
+    expect(call.to).toBe('user@example.com');
+    expect(call.replyTo).toBe('support@apptrack.ing');
+  });
+
+  it('includes the trial end date, amount, cadence, plan name, and manage URL in the html', async () => {
+    await sendTrialEndingEmail(BASE_OPTIONS);
+
+    const { html } = lastSendEmailCall();
+    expect(html).toContain('June 5, 2026');
+    expect(html).toContain('$9.00');
+    expect(html).toContain('month');
+    expect(html).toContain('AppTrack Pro');
+    expect(html).toContain('https://www.apptrack.ing/dashboard/settings');
+    // States the cancellation mechanism, not just a link.
+    expect(html).toContain('cancel before');
+  });
+
+  it('uses the transactional footer, not the Resume Roast marketing footer', async () => {
+    await sendTrialEndingEmail(BASE_OPTIONS);
+
+    const { html } = lastSendEmailCall();
+    expect(html).toContain('you have an active trial on AppTrack');
+    expect(html).toContain('Manage subscription');
+    expect(html).not.toContain('Resume Roast');
+    expect(html).not.toContain('Unsubscribe');
+  });
+
+  it('uses the amount-known subject with an em dash', async () => {
+    await sendTrialEndingEmail(BASE_OPTIONS);
+
+    const { subject } = lastSendEmailCall();
+    expect(subject).toBe(
+      "Your AppTrack trial ends June 5, 2026 — you'll be charged $9.00"
+    );
+    expect(subject).toContain('—');
+  });
+
+  it('uses the generic subject and renewal copy when amount is unknown', async () => {
+    await sendTrialEndingEmail({
+      ...BASE_OPTIONS,
+      amountFormatted: undefined,
+    });
+
+    const call = lastSendEmailCall();
+    expect(call.subject).toBe('Your AppTrack trial ends June 5, 2026');
+    expect(call.subject).not.toContain("you'll be charged");
+    expect(call.html).toContain('will renew');
+    expect(call.html).not.toContain("you'll be charged");
+  });
+
+  it('escapes interpolated values containing HTML', async () => {
+    await sendTrialEndingEmail({
+      ...BASE_OPTIONS,
+      planName: '<script>alert(1)</script>',
+    });
+
+    const { html } = lastSendEmailCall();
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
+  it('contains no emoji in the subject or body', async () => {
+    await sendTrialEndingEmail(BASE_OPTIONS);
+
+    const { subject, html } = lastSendEmailCall();
+    expect(EMOJI_REGEX.test(subject)).toBe(false);
+    expect(EMOJI_REGEX.test(html)).toBe(false);
+  });
+
+  it('returns success:false when the send fails', async () => {
+    mockSendEmail.mockRejectedValueOnce(new Error('resend down'));
+
+    const result = await sendTrialEndingEmail(BASE_OPTIONS);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('wrapEmail footer regression', () => {
+  beforeEach(() => {
+    mockSendEmail.mockReset();
+    mockSendEmail.mockResolvedValue({ success: true });
+  });
+
+  it('sendRoastReadyEmail still renders the original Resume Roast marketing footer', async () => {
+    await sendRoastReadyEmail({
+      email: 'user@example.com',
+      firstName: 'Jordan',
+      roastId: 'roast-123',
+    });
+
+    const { html } = lastSendEmailCall();
+    expect(html).toContain(
+      "You're receiving this because you used Resume Roast on AppTrack."
+    );
+    expect(html).toContain('Unsubscribe');
+    expect(html).not.toContain('you have an active trial on AppTrack');
+  });
+});

--- a/__tests__/services/subscription-update-notified.test.ts
+++ b/__tests__/services/subscription-update-notified.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tests that SubscriptionService.updateFromStripeWebhook forwards the
+ * trial_ending_notified_at idempotency stamp through to the Supabase
+ * `.update(...)` call.
+ *
+ * The DAL query under test is:
+ *   from("user_subscriptions")
+ *     .update(data)
+ *     .eq("stripe_subscription_id", ...)
+ *     .select()
+ *     .single()
+ *
+ * A chainable Supabase client stub is injected into the service constructor and
+ * records the object passed to `.update(...)` so the test can assert the field
+ * is plumbed through without any mapping.
+ */
+
+import { SubscriptionService } from "@/services/subscriptions";
+
+function buildSupabaseMock(updatedRow: unknown) {
+  const updateArgs: unknown[] = [];
+
+  const single = jest.fn().mockResolvedValue({ data: updatedRow, error: null });
+  const select = jest.fn().mockReturnValue({ single });
+  const eq = jest.fn().mockReturnValue({ select });
+  const update = jest.fn().mockImplementation((data: unknown) => {
+    updateArgs.push(data);
+    return { eq };
+  });
+  const from = jest.fn().mockReturnValue({ update });
+
+  return { supabase: { from }, updateArgs, update, eq };
+}
+
+const STRIPE_SUB_ID = "sub_stripe_123";
+
+describe("SubscriptionService.updateFromStripeWebhook trial_ending_notified_at", () => {
+  it("forwards trial_ending_notified_at to the Supabase update", async () => {
+    const notifiedAt = "2026-05-29T12:00:00.000Z";
+    const { supabase, updateArgs, eq } = buildSupabaseMock({
+      id: "sub-1",
+      stripe_subscription_id: STRIPE_SUB_ID,
+      trial_ending_notified_at: notifiedAt,
+    });
+
+    const service = new SubscriptionService(supabase as never);
+
+    const result = await service.updateFromStripeWebhook(STRIPE_SUB_ID, {
+      trial_ending_notified_at: notifiedAt,
+    });
+
+    expect(updateArgs[0]).toEqual({ trial_ending_notified_at: notifiedAt });
+    expect(eq).toHaveBeenCalledWith("stripe_subscription_id", STRIPE_SUB_ID);
+    expect(result?.trial_ending_notified_at).toBe(notifiedAt);
+  });
+});

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -10,6 +10,7 @@ import { loggerService } from "@/lib/services/logger.service";
 import { LogCategory } from "@/lib/services/logger.types";
 import { transitionAudience } from "@/lib/email/drip-scheduler";
 import { captureServerEvent } from "@/lib/analytics/posthog-server";
+import { sendTrialEndingEmail } from "@/lib/email/transactional";
 import type { SubscriptionStatus } from "@/lib/constants/subscription-status";
 
 const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET!;
@@ -93,6 +94,14 @@ export async function POST(request: NextRequest) {
         await handleSubscriptionCreated(
           event.data.object as Stripe.Subscription,
           subscriptionService
+        );
+        break;
+
+      case "customer.subscription.trial_will_end":
+        await handleTrialWillEnd(
+          event.data.object as Stripe.Subscription,
+          subscriptionService,
+          serviceClient
         );
         break;
 
@@ -657,6 +666,290 @@ async function handlePaymentFailed(
         invoiceId: invoice.id
       }
     });
+  }
+}
+
+const APP_URL =
+  process.env.APP_URL ||
+  process.env.NEXT_PUBLIC_APP_URL ||
+  "https://www.apptrack.ing";
+
+const TRIAL_PLAN_NAME_FALLBACK = "your AppTrack plan";
+
+/**
+ * Build human-readable charge cadence wording from a Stripe recurring price.
+ * The email renders "per <cadence>", so the multi-count branch must not include
+ * "every" (would read "per every 3 months").
+ * Examples: "month", "year", "3 months", "2 weeks".
+ */
+function formatCadence(
+  interval: Stripe.Price.Recurring.Interval,
+  intervalCount: number
+): string {
+  if (intervalCount > 1) {
+    return `${intervalCount} ${interval}s`;
+  }
+  return interval;
+}
+
+/**
+ * Format a charge amount (minor units) into a localized currency string.
+ * Returns `undefined` if the currency code is malformed: `Intl.NumberFormat`
+ * throws on a bad currency, and since this runs inside the handler's main try
+ * that would rethrow → infinite Stripe retries. Falling back to `undefined`
+ * lets the email use the generic "your plan will renew" copy instead.
+ */
+function formatChargeAmount(
+  unitAmountMinor: number,
+  currency: string
+): string | undefined {
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: currency.toUpperCase(),
+    }).format(unitAmountMinor / 100);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Format a trial-end Date for display with a pinned locale. */
+function formatTrialEndDate(date: Date): string {
+  return new Intl.DateTimeFormat("en-US", { dateStyle: "long" }).format(date);
+}
+
+/**
+ * Look up the plan display name by Stripe price id, returning a neutral
+ * fallback if not found or on error. Never throws — a missing plan name must
+ * not block a compliance-required pre-charge notice.
+ */
+async function resolvePlanName(
+  serviceClient: SupabaseClient,
+  priceId: string | undefined
+): Promise<string> {
+  if (!priceId) {
+    return TRIAL_PLAN_NAME_FALLBACK;
+  }
+  try {
+    const { data: plan } = await serviceClient
+      .from("subscription_plans")
+      .select("name")
+      .or(
+        `stripe_monthly_price_id.eq.${priceId},stripe_yearly_price_id.eq.${priceId}`
+      )
+      .maybeSingle();
+    return plan?.name || TRIAL_PLAN_NAME_FALLBACK;
+  } catch {
+    return TRIAL_PLAN_NAME_FALLBACK;
+  }
+}
+
+/**
+ * Handle Stripe's `customer.subscription.trial_will_end` event (~3 days before
+ * a paid trial charges) by sending the customer a pre-charge notice.
+ *
+ * Exported for unit testing (see __tests__/api/stripe-trial-will-end.test.ts).
+ *
+ * Skip-vs-rethrow policy: "skip" outcomes (no userId, already notified, won't
+ * charge, no email, no trial_end) are normal non-error states — they `return`
+ * inside the try and the catch is never reached, so the webhook returns 2xx and
+ * Stripe stops. Genuine failures (a `findByStripeSubscriptionId` throw, a send
+ * failure, or any unexpected throw) propagate to the catch, are logged, and are
+ * RETHROWN so the route returns non-2xx and Stripe retries — favoring delivery
+ * of a compliance notice. `trial_ending_notified_at` is stamped only after a
+ * successful send, so retries never double-notify.
+ */
+export async function handleTrialWillEnd(
+  subscription: Stripe.Subscription,
+  subscriptionService: SubscriptionService,
+  serviceClient: SupabaseClient
+) {
+  try {
+    // Resolve userId from metadata, falling back to the local row. We fetch the
+    // local row regardless because it also carries the idempotency timestamp.
+    const local = await subscriptionService.findByStripeSubscriptionId(
+      subscription.id
+    );
+    const userId = String(subscription.metadata?.userId || local?.user_id || "");
+    if (!userId) {
+      loggerService.warn("Skipping trial_will_end: unresolved userId", {
+        category: LogCategory.PAYMENT,
+        action: "trial_will_end_missing_user",
+        metadata: { subscriptionId: subscription.id },
+      });
+      return;
+    }
+
+    // Require the local row: it's the idempotency anchor. Without it we can't
+    // record that the notice was sent (updateFromStripeWebhook no-ops when no
+    // row matches), so sending would risk duplicates on Stripe redelivery. A
+    // real Stripe trial always has a local row by the time trial_will_end fires
+    // (created on customer.subscription.created).
+    if (!local) {
+      loggerService.warn("Skipping trial_will_end: no local row", {
+        category: LogCategory.PAYMENT,
+        userId,
+        action: "trial_will_end_no_local_row",
+        metadata: { subscriptionId: subscription.id },
+      });
+      return;
+    }
+
+    // Idempotency: never double-notify if we already sent this notice.
+    if (local?.trial_ending_notified_at) {
+      loggerService.info("Skipping trial_will_end: already notified", {
+        category: LogCategory.PAYMENT,
+        userId,
+        action: "trial_will_end_already_notified",
+        metadata: { subscriptionId: subscription.id },
+      });
+      return;
+    }
+
+    // Scope guard: only notify trials that will actually charge.
+    if (subscription.status !== "trialing" || subscription.cancel_at_period_end) {
+      loggerService.info("Skipping trial_will_end: not a charging trial", {
+        category: LogCategory.PAYMENT,
+        userId,
+        action: "trial_will_end_not_charging",
+        metadata: {
+          subscriptionId: subscription.id,
+          status: subscription.status,
+          cancelAtPeriodEnd: subscription.cancel_at_period_end,
+        },
+      });
+      return;
+    }
+
+    // The customer retrieve is required: for Checkout trials the card lives on
+    // the customer, not the (un-expanded) subscription payload.
+    const customer = await stripe.customers.retrieve(
+      subscription.customer as string
+    );
+    if ("deleted" in customer) {
+      loggerService.info("Skipping trial_will_end: customer deleted", {
+        category: LogCategory.PAYMENT,
+        userId,
+        action: "trial_will_end_customer_deleted",
+        metadata: { subscriptionId: subscription.id },
+      });
+      return;
+    }
+
+    const hasPaymentMethod = Boolean(
+      subscription.default_payment_method ||
+        customer.invoice_settings?.default_payment_method ||
+        customer.default_source
+    );
+    if (!hasPaymentMethod) {
+      loggerService.info("Skipping trial_will_end: no payment method on file", {
+        category: LogCategory.PAYMENT,
+        userId,
+        action: "trial_will_end_no_payment_method",
+        metadata: { subscriptionId: subscription.id },
+      });
+      return;
+    }
+
+    const email = customer.email;
+    if (!email) {
+      loggerService.info("Skipping trial_will_end: customer has no email", {
+        category: LogCategory.PAYMENT,
+        userId,
+        action: "trial_will_end_no_email",
+        metadata: { subscriptionId: subscription.id },
+      });
+      return;
+    }
+
+    if (!subscription.trial_end) {
+      loggerService.info("Skipping trial_will_end: no trial_end", {
+        category: LogCategory.PAYMENT,
+        userId,
+        action: "trial_will_end_no_trial_end",
+        metadata: { subscriptionId: subscription.id },
+      });
+      return;
+    }
+
+    // Don't email "your trial ends on <past date>" for a late/retried event.
+    if (subscription.trial_end * 1000 <= Date.now()) {
+      loggerService.info("Skipping trial_will_end: trial_end in the past", {
+        category: LogCategory.PAYMENT,
+        userId,
+        action: "trial_will_end_stale",
+        metadata: {
+          subscriptionId: subscription.id,
+          trialEnd: subscription.trial_end,
+        },
+      });
+      return;
+    }
+
+    const trialEndDate = formatTrialEndDate(
+      new Date(subscription.trial_end * 1000)
+    );
+
+    const price = subscription.items.data[0]?.price;
+    const unitAmount = price?.unit_amount ?? null;
+    const currency = price?.currency || "usd";
+    const interval = price?.recurring?.interval;
+    const intervalCount = price?.recurring?.interval_count || 1;
+
+    const amountFormatted =
+      unitAmount != null ? formatChargeAmount(unitAmount, currency) : undefined;
+    const cadence = interval
+      ? formatCadence(interval, intervalCount)
+      : "billing period";
+
+    const planName = await resolvePlanName(serviceClient, price?.id);
+
+    const manageUrl = `${APP_URL}/dashboard/settings`;
+
+    const result = await sendTrialEndingEmail({
+      email,
+      firstName: customer.name?.split(" ")[0] || undefined,
+      planName,
+      amountFormatted,
+      cadence,
+      trialEndDate,
+      manageUrl,
+    });
+
+    if (!result.success) {
+      // Throw so the outer catch rethrows → webhook returns non-2xx → Stripe
+      // retries. The row is left unstamped, so the retry will re-attempt.
+      throw new Error("sendTrialEndingEmail failed");
+    }
+
+    await subscriptionService.updateFromStripeWebhook(subscription.id, {
+      trial_ending_notified_at: new Date().toISOString(),
+    });
+
+    after(() =>
+      captureServerEvent(userId, "trial_ending_notified", {
+        subscription_id: subscription.id,
+        amount_cents: unitAmount ?? null,
+        currency,
+        interval,
+        trial_end: subscription.trial_end,
+      })
+    );
+
+    loggerService.info("Sent trial-ending notice", {
+      category: LogCategory.PAYMENT,
+      userId,
+      action: "trial_will_end_notified",
+      metadata: { subscriptionId: subscription.id },
+    });
+  } catch (error) {
+    loggerService.error("Error in handleTrialWillEnd", error as Error, {
+      category: LogCategory.PAYMENT,
+      action: "trial_will_end_error",
+      metadata: { subscriptionId: subscription.id },
+    });
+    // Rethrow so a genuine failure surfaces as non-2xx and Stripe retries.
+    throw error;
   }
 }
 

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -674,7 +674,9 @@ const APP_URL =
   process.env.NEXT_PUBLIC_APP_URL ||
   "https://www.apptrack.ing";
 
-const TRIAL_PLAN_NAME_FALLBACK = "your AppTrack plan";
+// Bare label so the email's "your ${planName} plan" / "for ${planName}" copy
+// reads correctly (a real plan name is also bare, e.g. "AI Coach").
+const TRIAL_PLAN_NAME_FALLBACK = "AppTrack";
 
 /**
  * Build human-readable charge cadence wording from a Stripe recurring price.
@@ -896,8 +898,12 @@ export async function handleTrialWillEnd(
     const interval = price?.recurring?.interval;
     const intervalCount = price?.recurring?.interval_count || 1;
 
+    // Treat a zero (or absent) amount as "unknown" so the email uses the generic
+    // renewal copy instead of a confusing "you'll be charged $0.00" line.
     const amountFormatted =
-      unitAmount != null ? formatChargeAmount(unitAmount, currency) : undefined;
+      unitAmount != null && unitAmount > 0
+        ? formatChargeAmount(unitAmount, currency)
+        : undefined;
     const cadence = interval
       ? formatCadence(interval, intervalCount)
       : "billing period";

--- a/dal/subscriptions/index.ts
+++ b/dal/subscriptions/index.ts
@@ -27,6 +27,7 @@ export interface UpdateSubscriptionInput {
   billing_cycle?: "monthly" | "yearly";
   current_period_start?: string;
   current_period_end?: string;
+  trial_ending_notified_at?: string | null;
   cancel_at_period_end?: boolean;
 }
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -206,6 +206,12 @@ Object.defineProperty(window, 'matchMedia', {
   })),
 })
 
+// jsdom does not implement scrollIntoView; components that call it from an
+// effect (e.g. chat auto-scroll) would otherwise throw inside a timer and flake.
+if (typeof window !== 'undefined' && window.HTMLElement) {
+  window.HTMLElement.prototype.scrollIntoView = jest.fn()
+}
+
 // Global test setup
 beforeEach(() => {
   // Clear all mocks before each test

--- a/lib/email/transactional.ts
+++ b/lib/email/transactional.ts
@@ -8,6 +8,7 @@
 
 import { sendEmail } from './client';
 import { getUnsubscribeUrl } from './drip-scheduler';
+import { SUPPORT_EMAIL } from '@/lib/constants/site-config';
 
 const APP_URL =
   process.env.APP_URL ||
@@ -40,8 +41,38 @@ export function safeUrl(url: string): string {
   return '#';
 }
 
-function wrapEmail(content: string, unsubscribeUrl: string): string {
+/**
+ * Build the default marketing footer (Resume Roast notice + unsubscribe link).
+ * Kept as a separate function so `wrapEmail` produces identical output when no
+ * custom footer is supplied.
+ */
+function defaultMarketingFooter(unsubscribeUrl: string): string {
   const safeUnsubscribeUrl = escapeHtml(unsubscribeUrl);
+  return `
+              <p style="margin: 0 0 8px; font-size: 12px; color: #71717a; text-align: center;">
+                You're receiving this because you used Resume Roast on AppTrack.
+              </p>
+              <p style="margin: 0; font-size: 12px; color: #71717a; text-align: center;">
+                <a href="${safeUnsubscribeUrl}" style="color: #71717a;">Unsubscribe</a>
+              </p>`;
+}
+
+/**
+ * Wrap email body content in the shared AppTrack template.
+ *
+ * @param content     Inner HTML of the email body.
+ * @param unsubscribeUrl  URL used by the default marketing footer.
+ * @param footerHtml  Optional footer markup rendered in place of the default
+ *                    marketing footer (e.g. a transactional billing footer).
+ *                    When omitted, the default footer is reproduced exactly so
+ *                    existing callers are unaffected.
+ */
+function wrapEmail(
+  content: string,
+  unsubscribeUrl: string,
+  footerHtml?: string
+): string {
+  const footer = footerHtml ?? defaultMarketingFooter(unsubscribeUrl);
   return `
 <!DOCTYPE html>
 <html>
@@ -66,13 +97,7 @@ function wrapEmail(content: string, unsubscribeUrl: string): string {
             </td>
           </tr>
           <tr>
-            <td style="padding: 24px 32px; background-color: #fafafa; border-top: 1px solid #e4e4e7;">
-              <p style="margin: 0 0 8px; font-size: 12px; color: #71717a; text-align: center;">
-                You're receiving this because you used Resume Roast on AppTrack.
-              </p>
-              <p style="margin: 0; font-size: 12px; color: #71717a; text-align: center;">
-                <a href="${safeUnsubscribeUrl}" style="color: #71717a;">Unsubscribe</a>
-              </p>
+            <td style="padding: 24px 32px; background-color: #fafafa; border-top: 1px solid #e4e4e7;">${footer}
             </td>
           </tr>
         </table>
@@ -299,6 +324,106 @@ export async function sendTryResultsEmail({
     });
     return { success: result.success };
   } catch (err) {
+    return { success: false };
+  }
+}
+
+// ─── Trial Ending Email (pre-charge billing notice) ──────────
+
+const TRIAL_ENDING_REPLY_TO = SUPPORT_EMAIL;
+
+export type SendTrialEndingEmailOptions = {
+  email: string;
+  firstName?: string;
+  planName: string;
+  /** Formatted charge amount (e.g. "$9.00"); omitted for metered/$0 plans. */
+  amountFormatted?: string;
+  /** Cadence wording for the charge, e.g. "month", "year", "3 months". */
+  cadence: string;
+  /** Human-readable trial end date already formatted for display. */
+  trialEndDate: string;
+  /** Linkable self-serve manage/cancel page (not the POST-only Stripe portal). */
+  manageUrl: string;
+};
+
+/**
+ * Build the transactional footer for billing notices: explains why the email
+ * was received and links to the manage/cancel surface. No marketing
+ * unsubscribe link — this is a required pre-charge notice.
+ */
+function trialEndingFooter(manageUrl: string): string {
+  const safeManageUrl = safeUrl(manageUrl);
+  return `
+              <p style="margin: 0 0 8px; font-size: 12px; color: #71717a; text-align: center;">
+                You're receiving this because you have an active trial on AppTrack.
+              </p>
+              <p style="margin: 0; font-size: 12px; color: #71717a; text-align: center;">
+                <a href="${safeManageUrl}" style="color: #71717a;">Manage subscription</a>
+              </p>`;
+}
+
+/**
+ * Send the pre-charge "your trial is ending" notice for paid Stripe trials.
+ *
+ * Mirrors the other senders: returns `{ success }` and returns `false` (rather
+ * than throwing) when the send fails, so the caller decides how to react. The
+ * webhook handler (Task 3) treats a falsy `success` as a delivery failure and
+ * rethrows to trigger a Stripe retry.
+ */
+export async function sendTrialEndingEmail({
+  email,
+  firstName,
+  planName,
+  amountFormatted,
+  cadence,
+  trialEndDate,
+  manageUrl,
+}: SendTrialEndingEmailOptions): Promise<{ success: boolean }> {
+  const safeName = firstName ? escapeHtml(firstName) : undefined;
+  const safePlanName = escapeHtml(planName);
+  const safeCadence = escapeHtml(cadence);
+  const safeTrialEndDate = escapeHtml(trialEndDate);
+  const safeAmount = amountFormatted ? escapeHtml(amountFormatted) : undefined;
+
+  const chargeLine = safeAmount
+    ? `When your trial ends, you'll be charged ${safeAmount} per ${safeCadence} for ${safePlanName}.`
+    : `When your trial ends, your ${safePlanName} plan will renew.`;
+
+  const subject = safeAmount
+    ? `Your AppTrack trial ends ${trialEndDate} — you'll be charged ${amountFormatted}`
+    : `Your AppTrack trial ends ${trialEndDate}`;
+
+  const html = wrapEmail(
+    `
+    <p style="margin: 0 0 16px; font-size: 16px; color: #18181b;">
+      ${safeName ? `Hi ${safeName},` : 'Hi there,'}
+    </p>
+    <p style="margin: 0 0 16px; font-size: 16px; color: #3f3f46;">
+      Your AppTrack trial ends on ${safeTrialEndDate}.
+    </p>
+    <p style="margin: 0 0 16px; font-size: 16px; color: #3f3f46;">
+      ${chargeLine}
+    </p>
+    <p style="margin: 0 0 16px; font-size: 16px; color: #3f3f46;">
+      To avoid being charged, cancel before ${safeTrialEndDate} from your subscription settings:
+    </p>
+    ${ctaButton('Manage subscription', manageUrl)}
+  `,
+    // Billing notices use the transactional footer, not the marketing one, so
+    // the unsubscribe URL argument is unused here.
+    '',
+    trialEndingFooter(manageUrl)
+  );
+
+  try {
+    const result = await sendEmail({
+      to: email,
+      subject,
+      html,
+      replyTo: TRIAL_ENDING_REPLY_TO,
+    });
+    return { success: result.success };
+  } catch {
     return { success: false };
   }
 }

--- a/lib/email/transactional.ts
+++ b/lib/email/transactional.ts
@@ -367,8 +367,8 @@ function trialEndingFooter(manageUrl: string): string {
  *
  * Mirrors the other senders: returns `{ success }` and returns `false` (rather
  * than throwing) when the send fails, so the caller decides how to react. The
- * webhook handler (Task 3) treats a falsy `success` as a delivery failure and
- * rethrows to trigger a Stripe retry.
+ * webhook handler treats a falsy `success` as a delivery failure and rethrows
+ * to trigger a Stripe webhook retry.
  */
 export async function sendTrialEndingEmail({
   email,

--- a/schemas/migrations/029_add_trial_ending_notified_at.sql
+++ b/schemas/migrations/029_add_trial_ending_notified_at.sql
@@ -1,0 +1,8 @@
+-- Migration: Add trial_ending_notified_at to user_subscriptions
+-- Idempotency guard for the pre-charge trial-ending email so the notification
+-- is sent at most once per subscription trial.
+
+ALTER TABLE public.user_subscriptions
+ADD COLUMN IF NOT EXISTS trial_ending_notified_at timestamptz NULL;
+
+COMMENT ON COLUMN public.user_subscriptions.trial_ending_notified_at IS 'Timestamp the pre-charge trial-ending email was sent. NULL until sent; used as an idempotency guard to avoid duplicate notifications.';

--- a/schemas/user_subscriptions.sql
+++ b/schemas/user_subscriptions.sql
@@ -6,6 +6,7 @@ create table public.user_subscriptions (
   billing_cycle text null default 'monthly'::text,
   current_period_start timestamp with time zone null default now(),
   current_period_end timestamp with time zone null,
+  trial_ending_notified_at timestamp with time zone null,
   stripe_subscription_id text null,
   stripe_customer_id text null,
   created_at timestamp with time zone null default now(),

--- a/types/index.ts
+++ b/types/index.ts
@@ -80,6 +80,7 @@ export interface Subscription {
   billing_cycle: "monthly" | "yearly";
   current_period_start: string;
   current_period_end: string;
+  trial_ending_notified_at?: string | null;
   cancel_at_period_end: boolean;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## Why
Stripe-checkout trials (the 7-day Pro/AI Coach trial) get **no warning before the card is charged** at trial end. Only promo trials get reminders today, and those say "you'll return to the free tier" — wrong for a trial that charges. Silent end-of-trial charges are a compliance risk (auto-renewal / negative-option notice laws) and drive chargebacks/churn. (A real trialing user recently churned here.)

## What
- **Webhook:** handle `customer.subscription.trial_will_end` (`handleTrialWillEnd`). Resolve the user; guard to trials that will actually charge — `status=trialing`, `!cancel_at_period_end`, and a payment method **on the customer** (`invoice_settings.default_payment_method`/`default_source`; the subscription field is null on the raw Checkout payload). Derive amount/cadence/date from the price; send the notice.
- **Email:** new `sendTrialEndingEmail` — states the trial end date, the amount + cadence to be charged (or generic "your plan will renew" when amount is unknown), **how to cancel before the date**, and a link to `/dashboard/settings` (the self-serve manage/cancel surface). Transactional footer via a parameterized `wrapEmail` (existing senders unchanged). Reply-to `SUPPORT_EMAIL`. No emojis.
- **Idempotency:** new `user_subscriptions.trial_ending_notified_at` column (migration `029`). Skip if set; stamp only after a successful send; **rethrow on failure so Stripe retries** (at-least-once delivery, dedupe on success). Requires a local row as the dedupe anchor (no row → skip, no send).
- **Guards:** stale/past `trial_end`, missing/zero amount (generic copy), unknown currency (defensive — no retry loop), deleted customer / no email. Emits `trial_ending_notified` (server PostHog event).

## Tests
Email content/footer/escaping + regression that existing senders' footer is unchanged; the `notified_at` stamp path; handler unit tests (happy path, card-on-customer-only, idempotent skip, cancel/no-payment-method/stale-trial_end/no-local-row skips, generic-amount copy, rethrow-on-send-failure, unresolved user). Full suite green (84 suites, 1326 passed); `tsc` adds no new errors.

## Launch checklist (ops — required)
1. **Disable Stripe's built-in "trial ending" email** (Dashboard - Subscriptions and emails) or customers get two notices.
2. `FROM_EMAIL` set to a verified-domain sender (a billing email from the Resend sandbox looks like spam).
3. Run migration `029_add_trial_ending_notified_at.sql`.
4. Enable `customer.subscription.trial_will_end` on the Stripe webhook endpoint.

## Known limitations (logged)
- Trial-end date is formatted in UTC (no per-user timezone) — can be off by a day near midnight UTC.
- Uses `items.data[0]` (single-plan today); multi-item subscriptions would reflect only the first item.
- `package.json` pins `"stripe": "latest"` — this handler couples to the Stripe object shape; not repinned here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trial-ending email notifications: Users now receive a pre-charge email when their trial is ending, including details about the upcoming charge amount, trial end date, billing cadence, plan name, and account management link.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jlamoreaux/apptrack/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->