### PR TITLE
Set email and name on PostHog identify after auth

### DIFF
--- a/components/analytics/auth-tracker.tsx
+++ b/components/analytics/auth-tracker.tsx
@@ -19,9 +19,11 @@ function getPersonProperties(user: User): Record<string, string> {
     properties.email = user.email
   }
 
-  const name = user.user_metadata?.full_name || user.user_metadata?.name
-  if (name) {
-    properties.name = name
+  // Use full_name to match the key set by the server identify route, so person
+  // profiles aren't fragmented across two different name properties.
+  const fullName = user.user_metadata?.full_name || user.user_metadata?.name
+  if (fullName) {
+    properties.full_name = fullName
   }
 
   return properties
@@ -48,8 +50,8 @@ export function AuthTracker() {
           session.user.app_metadata?.provider || 'email'
         )
       } else if (event === 'INITIAL_SESSION' && session?.user) {
-        // Re-establish client-side identity on page load in case localStorage
-        // was cleared. This is a no-op if already identified.
+        // Re-establish client-side identity on page load, refreshing the
+        // person's email/name properties in case localStorage was cleared.
         posthog.identify(session.user.id, getPersonProperties(session.user))
       } else if (event === 'SIGNED_OUT') {
         // Clear PostHog identity so the next session starts fresh anonymous

--- a/components/analytics/auth-tracker.tsx
+++ b/components/analytics/auth-tracker.tsx
@@ -2,8 +2,30 @@
 
 import { useEffect } from 'react'
 import posthog from 'posthog-js'
+import type { User } from '@supabase/supabase-js'
 import { supabase } from '@/lib/supabase/browser-client'
 import { analyticsAPI } from '@/lib/analytics'
+
+/**
+ * Build the person properties to set on the PostHog profile during identify.
+ * Without these, person records have email: None and high-intent users can't
+ * be identified. Only includes keys with values so we never overwrite an
+ * existing property with undefined.
+ */
+function getPersonProperties(user: User): Record<string, string> {
+  const properties: Record<string, string> = {}
+
+  if (user.email) {
+    properties.email = user.email
+  }
+
+  const name = user.user_metadata?.full_name || user.user_metadata?.name
+  if (name) {
+    properties.name = name
+  }
+
+  return properties
+}
 
 export function AuthTracker() {
   useEffect(() => {
@@ -14,8 +36,9 @@ export function AuthTracker() {
       if (event === 'SIGNED_IN' && session?.user) {
         // Identify user client-side so pageviews are attributed to their UUID.
         // posthog-js persists this in localStorage, so subsequent page loads
-        // stay identified without needing to call this again.
-        posthog.identify(session.user.id)
+        // stay identified without needing to call this again. Set email/name on
+        // the person profile so high-intent users are identifiable in PostHog.
+        posthog.identify(session.user.id, getPersonProperties(session.user))
 
         // Identify user server-side (fetches subscription plan + traffic source automatically)
         await analyticsAPI.identify()
@@ -27,7 +50,7 @@ export function AuthTracker() {
       } else if (event === 'INITIAL_SESSION' && session?.user) {
         // Re-establish client-side identity on page load in case localStorage
         // was cleared. This is a no-op if already identified.
-        posthog.identify(session.user.id)
+        posthog.identify(session.user.id, getPersonProperties(session.user))
       } else if (event === 'SIGNED_OUT') {
         // Clear PostHog identity so the next session starts fresh anonymous
         posthog.reset()


### PR DESCRIPTION
The client-side posthog.identify() call in AuthTracker only passed the
user's UUID with no $set properties, so PostHog person records had
email: None. The server-side /api/analytics/identify route sets email,
but it routes through posthog-js (client-only), so it is a no-op on the
server and never reaches PostHog.

Pass email and name from the Supabase session user to posthog.identify()
on both SIGNED_IN and INITIAL_SESSION so person profiles are populated
and high-intent users can be identified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced analytics with improved user identification, now capturing user email and name information for more detailed insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->