### PR TITLE
copy: frame the validation email as a WIP

### DIFF
--- a/lib/email/templates/career-validation.ts
+++ b/lib/email/templates/career-validation.ts
@@ -41,8 +41,8 @@ export function getCareerValidationHtml(params: CareerValidationTemplateParams):
       review time comes, and know your gaps before your manager does.
     </p>
     <p style="margin: 0 0 8px; font-size: 16px; color: ${EMAIL_THEME.body};">
-      It doesn't exist yet, but I'm building it now, and I want the people it's
-      for to shape it. Want in?
+      It's early and still coming together, and I want to build it with the
+      people it's for. Want in?
     </p>
     ${ctaButton('Join the waitlist', CAREER_VALIDATION_CTA_URL)}
     <p style="margin: 24px 0 0; font-size: 14px; color: ${EMAIL_THEME.muted}; text-align: center;">

--- a/scripts/send-career-validation-email.sh
+++ b/scripts/send-career-validation-email.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# Trigger the Career Companion Phase 0 validation email.
+#
+# Usage:
+#   ./scripts/send-career-validation-email.sh                 # dry run (counts only, sends nothing)
+#   ./scripts/send-career-validation-email.sh test you@x.com  # one test email, no marker, no events
+#   ./scripts/send-career-validation-email.sh send --yes      # REAL send to the whole list (requires --yes)
+#
+# Config (env or .env):
+#   CRON_SECRET                 required — Bearer token for the admin route
+#   CAREER_EMAIL_BASE_URL       optional — default http://localhost:3000
+#                               (set to https://www.apptrack.ing for production)
+#
+# The real send is single-shot: the campaign_sends marker makes a second call
+# return 409 unless you pass force. Inspect Resend before ever forcing.
+
+set -euo pipefail
+
+# Load CRON_SECRET / base url from .env if not already in the environment.
+if [ -f .env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env
+  set +a
+fi
+
+BASE_URL="${CAREER_EMAIL_BASE_URL:-http://localhost:3000}"
+ENDPOINT="${BASE_URL}/api/admin/career-validation-email"
+
+if [ -z "${CRON_SECRET:-}" ]; then
+  echo "Error: CRON_SECRET is not set (checked environment and .env)." >&2
+  exit 1
+fi
+
+MODE="${1:-dry-run}"
+
+post() {
+  # $1 = JSON body
+  curl -sS -X POST "$ENDPOINT" \
+    -H "Authorization: Bearer ${CRON_SECRET}" \
+    -H "Content-Type: application/json" \
+    -d "$1"
+  echo
+}
+
+case "$MODE" in
+  dry-run|dry|"")
+    echo "Dry run against ${ENDPOINT} (no email is sent):"
+    post '{"dryRun": true}'
+    ;;
+  test)
+    TEST_EMAIL="${2:-}"
+    if [ -z "$TEST_EMAIL" ]; then
+      echo "Usage: $0 test you@example.com" >&2
+      exit 1
+    fi
+    echo "Sending ONE test email to ${TEST_EMAIL}:"
+    post "{\"testEmail\": \"${TEST_EMAIL}\"}"
+    ;;
+  send)
+    if [ "${2:-}" != "--yes" ]; then
+      echo "Refusing to send to the whole list without --yes." >&2
+      echo "Run a dry run first, then: $0 send --yes" >&2
+      exit 1
+    fi
+    echo "REAL SEND to the full audience against ${ENDPOINT}:"
+    post '{}'
+    ;;
+  *)
+    echo "Unknown mode: $MODE (expected: dry-run | test | send)" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/send-career-validation-email.sh
+++ b/scripts/send-career-validation-email.sh
@@ -37,7 +37,7 @@ MODE="${1:-dry-run}"
 
 post() {
   # $1 = JSON body
-  curl -sS -X POST "$ENDPOINT" \
+  curl -sS --connect-timeout 10 --max-time 60 --fail-with-body -X POST "$ENDPOINT" \
     -H "Authorization: Bearer ${CRON_SECRET}" \
     -H "Content-Type: application/json" \
     -d "$1"
@@ -53,6 +53,12 @@ case "$MODE" in
     TEST_EMAIL="${2:-}"
     if [ -z "$TEST_EMAIL" ]; then
       echo "Usage: $0 test you@example.com" >&2
+      exit 1
+    fi
+    # Validate before interpolating into the JSON body: a strict address has no
+    # quotes/backslashes/spaces, so it can't break out of the JSON string.
+    if ! printf '%s' "$TEST_EMAIL" | grep -qE '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$'; then
+      echo "Error: '$TEST_EMAIL' is not a valid email address." >&2
       exit 1
     fi
     echo "Sending ONE test email to ${TEST_EMAIL}:"


### PR DESCRIPTION
Reworks the closing line of the Career Companion validation email so it reads as an honest work-in-progress instead of vaporware.

**Before:** "It doesn't exist yet, but I'm building it now, and I want the people it's for to shape it. Want in?"
**After:** "It's early and still coming together, and I want to build it with the people it's for. Want in?"

Verified by rendering the template to HTML (the `/career` page already used WIP framing; this brings the email in line).

Also adds `scripts/send-career-validation-email.sh` — the owner-triggered helper for the send flow:
- `./scripts/send-career-validation-email.sh` → dry run (counts only)
- `… test you@x.com` → single test email (no marker, no events)
- `… send --yes` → real send to the list (guarded behind `--yes`; single-shot via the `campaign_sends` marker)

Reads `CRON_SECRET` from env/`.env`, base URL via `CAREER_EMAIL_BASE_URL` (default localhost; set `https://www.apptrack.ing` for prod).

Note: the real send reads the **deployed** template, so this needs to merge + deploy before the list send.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool to preview, test, and send Career Companion validation emails, with safe modes and an explicit confirmation requirement for full sends.

* **Content Updates**
  * Updated the Career Companion validation email wording to better reflect an early stage and ongoing, people-centered collaboration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->