### PR TITLE
feat: one-click waitlist join from email (signed token)

### DIFF
--- a/__tests__/api/career-waitlist.test.ts
+++ b/__tests__/api/career-waitlist.test.ts
@@ -17,6 +17,7 @@ import { captureServerEvent } from "@/lib/analytics/posthog-server";
 import { CAREER_EVENTS } from "@/lib/analytics/career-events";
 import { emailDistinctId } from "@/lib/analytics/anonymize";
 import { REVIEW_TIMING_OPTIONS } from "@/lib/constants/career";
+import { generateWaitlistToken } from "@/lib/career/waitlist-token";
 
 jest.mock("@/lib/supabase/server", () => ({
   createClient: jest.fn(),
@@ -46,6 +47,7 @@ const VALID_REVIEW_TIMING = REVIEW_TIMING_OPTIONS[0].value; // 'lt_3_months'
 let mockUpsert: jest.Mock;
 let mockUpsertSelect: jest.Mock;
 let mockGetUser: jest.Mock;
+let mockProfileMaybeSingle: jest.Mock;
 
 function makeRequest(body: unknown, ip = "203.0.113.10") {
   return new NextRequest("http://localhost:3000/api/career-waitlist", {
@@ -91,8 +93,19 @@ beforeEach(() => {
     .fn()
     .mockResolvedValue({ data: [{ id: "new-row-id" }], error: null });
   mockUpsert = jest.fn(() => ({ select: mockUpsertSelect }));
+  // Default: token path finds no matching profile (anonymous recipient).
+  mockProfileMaybeSingle = jest
+    .fn()
+    .mockResolvedValue({ data: null, error: null });
   mockCreateServiceRoleClient.mockReturnValue({
-    from: jest.fn(() => ({ upsert: mockUpsert })),
+    from: jest.fn((table: string) => {
+      if (table === "profiles") {
+        return {
+          select: () => ({ eq: () => ({ maybeSingle: mockProfileMaybeSingle }) }),
+        };
+      }
+      return { upsert: mockUpsert };
+    }),
   });
 
   mockCaptureServerEvent.mockResolvedValue(undefined);
@@ -139,22 +152,20 @@ describe("POST /api/career-waitlist", () => {
       expect(mockUpsert).not.toHaveBeenCalled();
     });
 
-    it("rejects an unknown review_timing instead of letting the DB CHECK 500", async () => {
+    it("stores null (not a 400 or DB CHECK 500) for an unknown review_timing", async () => {
       const res = await POST(
         makeRequest(validBody({ review_timing: "next_century" }))
       );
-      const data = await res.json();
 
-      expect(res.status).toBe(400);
-      expect(data.error).toContain("performance review");
-      expect(mockUpsert).not.toHaveBeenCalled();
+      expect(res.status).toBe(200);
+      expect(upsertedRow().review_timing).toBeNull();
     });
 
-    it("rejects a missing review_timing", async () => {
+    it("accepts a missing review_timing (the question is optional now)", async () => {
       const res = await POST(makeRequest({ email: "jordan@example.com" }));
 
-      expect(res.status).toBe(400);
-      expect(mockUpsert).not.toHaveBeenCalled();
+      expect(res.status).toBe(200);
+      expect(upsertedRow().review_timing).toBeNull();
     });
   });
 
@@ -180,6 +191,68 @@ describe("POST /api/career-waitlist", () => {
         expect.any(Number)
       );
       expect(mockUpsert).not.toHaveBeenCalled();
+      expect(mockCaptureServerEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("one-click token join", () => {
+    it("joins the token's email with null review_timing and source 'email'", async () => {
+      const token = generateWaitlistToken("Recipient@Example.com");
+      const res = await POST(makeRequest({ token }));
+
+      expect(res.status).toBe(200);
+      const row = upsertedRow();
+      expect(row.email).toBe("recipient@example.com");
+      expect(row.review_timing).toBeNull();
+      expect(row.source).toBe("email");
+    });
+
+    it("resolves user_id by looking the token email up in profiles", async () => {
+      mockProfileMaybeSingle.mockResolvedValue({
+        data: { id: "profile-user-9" },
+        error: null,
+      });
+      const token = generateWaitlistToken("member@example.com");
+
+      await POST(makeRequest({ token }));
+
+      expect(upsertedRow().user_id).toBe("profile-user-9");
+      expect(mockCaptureServerEvent).toHaveBeenCalledWith(
+        "profile-user-9",
+        CAREER_EVENTS.WAITLIST_JOINED,
+        expect.any(Object)
+      );
+    });
+
+    it("falls back to a hashed-email distinct id when the recipient isn't a user", async () => {
+      const token = generateWaitlistToken("stranger@example.com");
+
+      await POST(makeRequest({ token }));
+
+      expect(mockCaptureServerEvent).toHaveBeenCalledWith(
+        emailDistinctId("stranger@example.com"),
+        CAREER_EVENTS.WAITLIST_JOINED,
+        expect.any(Object)
+      );
+    });
+
+    it("rejects a forged/invalid token with 400 and never inserts", async () => {
+      const res = await POST(makeRequest({ token: "not-a-real-token.deadbeef" }));
+      const data = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(data.error).toContain("Invalid");
+      expect(mockUpsert).not.toHaveBeenCalled();
+      expect(mockCaptureServerEvent).not.toHaveBeenCalled();
+    });
+
+    it("is idempotent: a re-click (conflict) succeeds with no event", async () => {
+      mockUpsertSelect.mockResolvedValue({ data: [], error: null });
+      const token = generateWaitlistToken("repeat@example.com");
+
+      const res = await POST(makeRequest({ token }));
+
+      expect(res.status).toBe(200);
       expect(mockCaptureServerEvent).not.toHaveBeenCalled();
     });
   });

--- a/__tests__/components/career-waitlist-form.test.tsx
+++ b/__tests__/components/career-waitlist-form.test.tsx
@@ -1,20 +1,17 @@
 /**
- * Tests for the /career waitlist join form (Task 4):
+ * Tests for the /career waitlist join form:
  * - renders + prefills email from userEmail
- * - review-timing dropdown options come from REVIEW_TIMING_OPTIONS
- * - successful submit posts the right contract + shows the confirmation state
+ * - manual submit posts the right contract (email + source + utm) and shows the
+ *   confirmation; no review-timing question anymore
  * - 400 / 429 / network errors are surfaced inline (no silent failures)
- * - career_waitlist_viewed fires on mount with the derived source
- * - career_email_clicked fires only when utm_campaign matches CAREER_CAMPAIGN
+ * - career_waitlist_viewed / career_email_clicked fire per the derived source
+ * - a signed token in the URL auto-joins (one click), falling back to the form
+ *   if the token is rejected
  */
 
-import type { ReactNode } from "react";
-import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { CareerWaitlistForm } from "@/app/(marketing)/career/career-waitlist-form";
-import {
-  REVIEW_TIMING_OPTIONS,
-  CAREER_CAMPAIGN,
-} from "@/lib/constants/career";
+import { CAREER_CAMPAIGN } from "@/lib/constants/career";
 
 // --- next/navigation: per-test searchParams -------------------------------
 let mockSearchParams = new URLSearchParams();
@@ -43,42 +40,8 @@ jest.mock(
   { virtual: true }
 );
 
-// --- Radix Select -> testable lightweight equivalent ----------------------
-// Captures onValueChange so a test can pick a value, and renders each option's
-// label so option assertions work without driving Radix pointer events.
-let selectOnValueChange: ((value: string) => void) | undefined;
-jest.mock("@/components/ui/select", () => {
-  const Passthrough = ({ children }: { children?: ReactNode }) => <>{children}</>;
-  return {
-    Select: ({
-      children,
-      onValueChange,
-    }: {
-      children?: ReactNode;
-      onValueChange?: (value: string) => void;
-    }) => {
-      selectOnValueChange = onValueChange;
-      return <div>{children}</div>;
-    },
-    SelectTrigger: Passthrough,
-    SelectValue: ({ placeholder }: { placeholder?: string }) => (
-      <span>{placeholder}</span>
-    ),
-    SelectContent: Passthrough,
-    SelectItem: ({ children, value }: { children?: ReactNode; value?: string }) => (
-      <div data-value={value}>{children}</div>
-    ),
-  };
-});
-
 const mockFetch = jest.fn();
 global.fetch = mockFetch as unknown as typeof fetch;
-
-function selectFirstTiming() {
-  act(() => {
-    selectOnValueChange?.(REVIEW_TIMING_OPTIONS[0].value);
-  });
-}
 
 function submit() {
   fireEvent.click(screen.getByRole("button", { name: /join the waitlist/i }));
@@ -89,7 +52,6 @@ describe("CareerWaitlistForm", () => {
     jest.clearAllMocks();
     mockFetch.mockReset();
     mockSearchParams = new URLSearchParams();
-    selectOnValueChange = undefined;
   });
 
   it("prefills the email input from userEmail", () => {
@@ -102,11 +64,11 @@ describe("CareerWaitlistForm", () => {
     expect(screen.getByLabelText("Email")).toHaveValue("");
   });
 
-  it("renders every review-timing option from the constants", () => {
+  it("no longer shows a review-timing question", () => {
     render(<CareerWaitlistForm userEmail={null} />);
-    for (const option of REVIEW_TIMING_OPTIONS) {
-      expect(screen.getByText(option.label)).toBeInTheDocument();
-    }
+    expect(
+      screen.queryByText(/next performance review/i)
+    ).not.toBeInTheDocument();
   });
 
   it("fires career_waitlist_viewed on mount with derived source 'direct'", () => {
@@ -151,18 +113,7 @@ describe("CareerWaitlistForm", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("requires a review-timing selection before submitting", async () => {
-    render(<CareerWaitlistForm userEmail="user@example.com" />);
-    submit();
-    await waitFor(() => {
-      expect(
-        screen.getByText("Please select when your next review is")
-      ).toBeInTheDocument();
-    });
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
-
-  it("posts the expected contract and shows the confirmation on success", async () => {
+  it("posts email + source + utm (no review_timing) and shows the confirmation", async () => {
     mockSearchParams = new URLSearchParams({ utm_medium: "email" });
     mockFetch.mockResolvedValueOnce({
       ok: true,
@@ -171,25 +122,20 @@ describe("CareerWaitlistForm", () => {
     });
 
     render(<CareerWaitlistForm userEmail="user@example.com" />);
-    selectFirstTiming();
     submit();
 
     await waitFor(() => {
       expect(screen.getByText("You're on the list.")).toBeInTheDocument();
     });
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      "/api/career-waitlist",
-      expect.objectContaining({ method: "POST" })
-    );
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
     expect(body).toMatchObject({
       email: "user@example.com",
-      review_timing: REVIEW_TIMING_OPTIONS[0].value,
       source: "email",
       utm: { utm_source: "email" },
       ph_distinct_id: "ph_abc",
     });
+    expect(body).not.toHaveProperty("review_timing");
   });
 
   it("surfaces the server 400 message inline", async () => {
@@ -200,7 +146,6 @@ describe("CareerWaitlistForm", () => {
     });
 
     render(<CareerWaitlistForm userEmail="user@example.com" />);
-    selectFirstTiming();
     submit();
 
     await waitFor(() => {
@@ -219,7 +164,6 @@ describe("CareerWaitlistForm", () => {
     });
 
     render(<CareerWaitlistForm userEmail="user@example.com" />);
-    selectFirstTiming();
     submit();
 
     await waitFor(() => {
@@ -233,13 +177,51 @@ describe("CareerWaitlistForm", () => {
     mockFetch.mockRejectedValueOnce(new Error("network down"));
 
     render(<CareerWaitlistForm userEmail="user@example.com" />);
-    selectFirstTiming();
     submit();
 
     await waitFor(() => {
       expect(
         screen.getByText("Something went wrong. Please try again.")
       ).toBeInTheDocument();
+    });
+  });
+
+  describe("one-click token (t param)", () => {
+    it("auto-joins with the token and shows the confirmation, no form", async () => {
+      mockSearchParams = new URLSearchParams({ t: "signed.token", utm_medium: "email" });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true }),
+      });
+
+      render(<CareerWaitlistForm userEmail={null} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("You're on the list.")).toBeInTheDocument();
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body).toMatchObject({ token: "signed.token", source: "email" });
+      expect(body).not.toHaveProperty("email");
+      // The manual form never rendered.
+      expect(screen.queryByLabelText("Email")).not.toBeInTheDocument();
+    });
+
+    it("falls back to the manual form when the token is rejected", async () => {
+      mockSearchParams = new URLSearchParams({ t: "bad.token" });
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: "Invalid or expired link." }),
+      });
+
+      render(<CareerWaitlistForm userEmail={null} />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Email")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("You're on the list.")).not.toBeInTheDocument();
     });
   });
 });

--- a/__tests__/lib/career/waitlist-token.test.ts
+++ b/__tests__/lib/career/waitlist-token.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Signed waitlist token: round-trips the email, and rejects any tampering so a
+ * forged link can't register an email the sender doesn't control.
+ */
+import {
+  generateWaitlistToken,
+  verifyWaitlistToken,
+} from "@/lib/career/waitlist-token";
+
+describe("waitlist token", () => {
+  it("round-trips the normalized email", () => {
+    const token = generateWaitlistToken("  Jordan@Example.COM ");
+    expect(verifyWaitlistToken(token)).toBe("jordan@example.com");
+  });
+
+  it("rejects a tampered signature", () => {
+    const token = generateWaitlistToken("jordan@example.com");
+    const [payload] = token.split(".");
+    expect(verifyWaitlistToken(`${payload}.deadbeef`)).toBeNull();
+  });
+
+  it("rejects a swapped payload (can't forge another email)", () => {
+    const token = generateWaitlistToken("jordan@example.com");
+    const signature = token.split(".")[1];
+    const forgedPayload = Buffer.from("victim@example.com").toString("base64url");
+    expect(verifyWaitlistToken(`${forgedPayload}.${signature}`)).toBeNull();
+  });
+
+  it("rejects malformed / non-string input", () => {
+    expect(verifyWaitlistToken("no-dot-here")).toBeNull();
+    expect(verifyWaitlistToken("")).toBeNull();
+    expect(verifyWaitlistToken(undefined)).toBeNull();
+    expect(verifyWaitlistToken(12345)).toBeNull();
+  });
+});

--- a/app/(marketing)/career/career-waitlist-form.tsx
+++ b/app/(marketing)/career/career-waitlist-form.tsx
@@ -7,18 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
-  REVIEW_TIMING_OPTIONS,
-  CAREER_CAMPAIGN,
-  type CareerWaitlistSource,
-} from "@/lib/constants/career";
+import { CAREER_CAMPAIGN, type CareerWaitlistSource } from "@/lib/constants/career";
 import {
   trackCareerWaitlistViewed,
   trackCareerEmailClicked,
@@ -56,6 +45,9 @@ export function CareerWaitlistForm({ userEmail }: CareerWaitlistFormProps) {
   // Persist UTMs from the email/banner link into sessionStorage for this session.
   useUTMTracking();
 
+  // Signed one-click token from the email link. Present → join automatically.
+  const joinToken = searchParams.get("t");
+
   const source: CareerWaitlistSource = useMemo(() => {
     const medium = searchParams.get("utm_medium");
     const utmSource = searchParams.get("utm_source");
@@ -65,12 +57,13 @@ export function CareerWaitlistForm({ userEmail }: CareerWaitlistFormProps) {
   }, [searchParams]);
 
   const [email, setEmail] = useState(userEmail ?? "");
-  const [reviewTiming, setReviewTiming] = useState("");
   const [emailError, setEmailError] = useState("");
-  const [timingError, setTimingError] = useState("");
   const [submitError, setSubmitError] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [joined, setJoined] = useState(false);
+  // True while the token is being redeemed. Starts true when a token is present
+  // so scanners that don't run JS never trigger a join (the POST is what joins).
+  const [autoJoining, setAutoJoining] = useState(Boolean(joinToken));
 
   // Fire viewed once on mount; email_clicked only when arriving from the
   // validation email (utm_campaign match). Both are de-duped downstream.
@@ -83,6 +76,38 @@ export function CareerWaitlistForm({ userEmail }: CareerWaitlistFormProps) {
       trackCareerEmailClicked();
     }
   }, [source, searchParams]);
+
+  // One-click join: redeem the token via a POST on mount. Runs only in a real
+  // browser, so email link-scanners that prefetch the URL don't create joins.
+  const autoJoinRef = useRef(false);
+  useEffect(() => {
+    if (!joinToken || autoJoinRef.current) return;
+    autoJoinRef.current = true;
+    (async () => {
+      try {
+        const phDistinctId = await getPhDistinctId();
+        const response = await fetch("/api/career-waitlist", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            token: joinToken,
+            source,
+            utm: getStoredUTMParams(),
+            ph_distinct_id: phDistinctId,
+          }),
+        });
+        if (response.ok) {
+          setJoined(true);
+          return;
+        }
+        // Invalid/expired token or a transient failure: fall back to the manual
+        // form so the visitor can still join by typing their email.
+        setAutoJoining(false);
+      } catch {
+        setAutoJoining(false);
+      }
+    })();
+  }, [joinToken, source]);
 
   // Success state replaces the form entirely — no silent failures, no lingering form.
   if (joined) {
@@ -101,11 +126,22 @@ export function CareerWaitlistForm({ userEmail }: CareerWaitlistFormProps) {
     );
   }
 
+  // Redeeming the one-click token.
+  if (autoJoining) {
+    return (
+      <div className="bg-card border border-border rounded-xl p-6 sm:p-8 text-center">
+        <div className="flex flex-col items-center gap-3">
+          <Spinner size="sm" />
+          <p className="text-sm text-muted-foreground">Adding you to the list…</p>
+        </div>
+      </div>
+    );
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setSubmitError("");
     setEmailError("");
-    setTimingError("");
 
     // Client-side quick checks before hitting the network.
     if (!email.trim()) {
@@ -114,10 +150,6 @@ export function CareerWaitlistForm({ userEmail }: CareerWaitlistFormProps) {
     }
     if (!isValidEmailFormat(email.trim())) {
       setEmailError("Please enter a valid email address");
-      return;
-    }
-    if (!reviewTiming) {
-      setTimingError("Please select when your next review is");
       return;
     }
 
@@ -129,7 +161,6 @@ export function CareerWaitlistForm({ userEmail }: CareerWaitlistFormProps) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           email: email.trim(),
-          review_timing: reviewTiming,
           source,
           utm: getStoredUTMParams(),
           ph_distinct_id: phDistinctId,
@@ -187,41 +218,6 @@ export function CareerWaitlistForm({ userEmail }: CareerWaitlistFormProps) {
         {emailError && (
           <p id="career-email-error" className="text-sm text-destructive">
             {emailError}
-          </p>
-        )}
-      </div>
-
-      <div className="space-y-1.5">
-        <Label htmlFor="review-timing">
-          When is your next performance review?
-        </Label>
-        <Select
-          value={reviewTiming}
-          onValueChange={(value) => {
-            setReviewTiming(value);
-            if (timingError) setTimingError("");
-          }}
-          disabled={isSubmitting}
-        >
-          <SelectTrigger
-            id="review-timing"
-            className="min-h-[44px]"
-            aria-invalid={timingError ? true : undefined}
-            aria-describedby={timingError ? "review-timing-error" : undefined}
-          >
-            <SelectValue placeholder="Select timing" />
-          </SelectTrigger>
-          <SelectContent>
-            {REVIEW_TIMING_OPTIONS.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        {timingError && (
-          <p id="review-timing-error" className="text-sm text-destructive">
-            {timingError}
           </p>
         )}
       </div>

--- a/app/api/admin/career-validation-email/route.ts
+++ b/app/api/admin/career-validation-email/route.ts
@@ -204,7 +204,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   const getHtml = (params: { email: string; firstName?: string; unsubscribeUrl: string }) =>
-    getCareerValidationHtml({ firstName: params.firstName, unsubscribeUrl: params.unsubscribeUrl });
+    getCareerValidationHtml({
+      firstName: params.firstName,
+      email: params.email,
+      unsubscribeUrl: params.unsubscribeUrl,
+    });
 
   if (body.testEmail !== undefined) {
     // Untrusted JSON: reject a non-string testEmail before it reaches

--- a/app/api/career-waitlist/route.ts
+++ b/app/api/career-waitlist/route.ts
@@ -24,6 +24,7 @@ import { createServiceRoleClient } from "@/lib/supabase/service-role-client";
 import { captureServerEvent } from "@/lib/analytics/posthog-server";
 import { CAREER_EVENT_NAMES } from "@/lib/analytics/career-event-names";
 import { emailDistinctId } from "@/lib/analytics/anonymize";
+import { verifyWaitlistToken } from "@/lib/career/waitlist-token";
 
 const CAREER_WAITLIST_JOINED_EVENT = CAREER_EVENT_NAMES.WAITLIST_JOINED;
 
@@ -54,15 +55,18 @@ function isReviewTiming(value: unknown): value is ReviewTiming {
   return typeof value === "string" && REVIEW_TIMING_VALUES.includes(value);
 }
 
-/** Unknown or missing sources are coerced to 'direct' (never a 400 or DB CHECK 500). */
-function coerceSource(value: unknown): CareerWaitlistSource {
+/** Unknown or missing sources are coerced to a caller-provided default (never a 400 or DB CHECK 500). */
+function coerceSource(
+  value: unknown,
+  fallback: CareerWaitlistSource = "direct"
+): CareerWaitlistSource {
   if (
     typeof value === "string" &&
     (CAREER_WAITLIST_SOURCES as readonly string[]).includes(value)
   ) {
     return value as CareerWaitlistSource;
   }
-  return "direct";
+  return fallback;
 }
 
 /**
@@ -157,38 +161,60 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const rawEmail = body.email;
-    if (typeof rawEmail !== "string" || rawEmail.trim() === "") {
-      return NextResponse.json({ error: "Email is required" }, { status: 400 });
-    }
+    const serviceClient = createServiceRoleClient();
 
-    const email = normalizeEmail(rawEmail);
-    const emailValidation = validateEmail(email);
-    if (!emailValidation.valid) {
-      return NextResponse.json(
-        { error: emailValidation.message ?? "Please enter a valid email address" },
-        { status: 400 }
-      );
-    }
-
-    if (!isReviewTiming(body.review_timing)) {
-      return NextResponse.json(
-        { error: "Please select when your next performance review is" },
-        { status: 400 }
-      );
-    }
-    const reviewTiming = body.review_timing;
-    const source = coerceSource(body.source);
+    // review_timing is optional (the one-click flow drops the question). When
+    // present and valid it's recorded; otherwise it's null.
+    const reviewTiming: ReviewTiming | null = isReviewTiming(body.review_timing)
+      ? body.review_timing
+      : null;
     const utm = whitelistUtmParams(body.utm);
 
-    // user_id comes ONLY from the server session — never from the payload.
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    const userId = user?.id ?? null;
+    let email: string;
+    let userId: string | null;
+    let source: CareerWaitlistSource;
 
-    const serviceClient = createServiceRoleClient();
+    if (body.token !== undefined) {
+      // One-click join from a signed email link. The token authenticates the
+      // recipient's email, so it's trusted (no disposable-domain check) and the
+      // user is resolved by looking the email up in profiles rather than by
+      // session (the click is usually logged out).
+      const tokenEmail = verifyWaitlistToken(body.token);
+      if (!tokenEmail) {
+        return NextResponse.json({ error: "Invalid or expired link." }, { status: 400 });
+      }
+      email = normalizeEmail(tokenEmail);
+      source = coerceSource(body.source, "email");
+      const { data: profile } = await serviceClient
+        .from("profiles")
+        .select("id")
+        .eq("email", email)
+        .maybeSingle();
+      userId = profile?.id ?? null;
+    } else {
+      // Form join (direct/banner): email is required and fully validated.
+      const rawEmail = body.email;
+      if (typeof rawEmail !== "string" || rawEmail.trim() === "") {
+        return NextResponse.json({ error: "Email is required" }, { status: 400 });
+      }
+      email = normalizeEmail(rawEmail);
+      const emailValidation = validateEmail(email);
+      if (!emailValidation.valid) {
+        return NextResponse.json(
+          { error: emailValidation.message ?? "Please enter a valid email address" },
+          { status: 400 }
+        );
+      }
+      source = coerceSource(body.source);
+
+      // user_id comes ONLY from the server session — never from the payload.
+      const supabase = await createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      userId = user?.id ?? null;
+    }
+
     const { data: insertedRows, error: insertError } = await serviceClient
       .from("career_waitlist")
       .upsert(

--- a/lib/career/waitlist-token.ts
+++ b/lib/career/waitlist-token.ts
@@ -1,0 +1,53 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+/**
+ * Signed, self-contained tokens for one-click waitlist joins from email links.
+ *
+ * The token encodes the recipient's email and an HMAC signature, so a link like
+ * `/career?t=<token>` identifies the recipient without a raw email in the URL
+ * and without the server having to trust a client-supplied address. The HMAC
+ * (server secret) is what matters: an attacker cannot forge a valid token for
+ * an email they don't control, so they cannot register someone else.
+ */
+const TOKEN_SECRET =
+  process.env.WAITLIST_TOKEN_SECRET ||
+  process.env.UNSUBSCRIBE_SECRET ||
+  process.env.CRON_SECRET ||
+  "fallback-secret-change-me";
+
+function sign(payload: string): string {
+  return createHmac("sha256", TOKEN_SECRET).update(payload).digest("hex");
+}
+
+export function generateWaitlistToken(email: string): string {
+  const payload = Buffer.from(email.trim().toLowerCase()).toString("base64url");
+  return `${payload}.${sign(payload)}`;
+}
+
+/** Returns the normalized email if the token is authentic, else null. */
+export function verifyWaitlistToken(token: unknown): string | null {
+  if (typeof token !== "string" || !token.includes(".")) {
+    return null;
+  }
+  const [payload, signature] = token.split(".");
+  if (!payload || !signature) {
+    return null;
+  }
+
+  const expected = sign(payload);
+  try {
+    if (!timingSafeEqual(Buffer.from(signature), Buffer.from(expected))) {
+      return null;
+    }
+  } catch {
+    // Length mismatch throws in timingSafeEqual — treat as invalid.
+    return null;
+  }
+
+  try {
+    const email = Buffer.from(payload, "base64url").toString("utf8");
+    return email.length > 0 ? email : null;
+  } catch {
+    return null;
+  }
+}

--- a/lib/email/templates/career-validation.ts
+++ b/lib/email/templates/career-validation.ts
@@ -6,11 +6,24 @@
  */
 
 import { CAREER_CAMPAIGN } from '@/lib/constants/career';
+import { generateWaitlistToken } from '@/lib/career/waitlist-token';
 import { APP_URL, ctaButton, escapeHtml, EMAIL_THEME, wrapEmail } from './shared';
 
 export const CAREER_VALIDATION_SUBJECT = "Let's build a case for your next raise.";
 
 export const CAREER_VALIDATION_CTA_URL = `${APP_URL}/career?utm_source=email&utm_medium=email&utm_campaign=${CAREER_CAMPAIGN}`;
+
+/**
+ * Per-recipient CTA: appends a signed token so clicking joins the recipient in
+ * one click (no form) without a raw email in the URL. Falls back to the plain
+ * form URL when the email is unknown.
+ */
+export function careerValidationCtaUrl(email?: string): string {
+  if (!email) {
+    return CAREER_VALIDATION_CTA_URL;
+  }
+  return `${CAREER_VALIDATION_CTA_URL}&t=${encodeURIComponent(generateWaitlistToken(email))}`;
+}
 
 // Sent personally from the founder so it reads as a direct note, not a
 // company blast, with replies routed to a real inbox. The route resolves
@@ -22,11 +35,14 @@ export const DEFAULT_CAREER_VALIDATION_REPLY_TO = 'jordan@apptrack.ing';
 
 export type CareerValidationTemplateParams = {
   firstName?: string;
+  /** Recipient email — signs the one-click join token on the CTA. */
+  email?: string;
   unsubscribeUrl: string;
 };
 
 export function getCareerValidationHtml(params: CareerValidationTemplateParams): string {
   const greeting = params.firstName ? `Hi ${escapeHtml(params.firstName)},` : 'Hi there,';
+  const ctaUrl = careerValidationCtaUrl(params.email);
 
   const content = `
     <p style="margin: 0 0 16px; font-size: 16px; color: ${EMAIL_THEME.heading};">
@@ -44,7 +60,7 @@ export function getCareerValidationHtml(params: CareerValidationTemplateParams):
       It's early and still coming together, and I want to build it with the
       people it's for. Want in?
     </p>
-    ${ctaButton('Join the waitlist', CAREER_VALIDATION_CTA_URL)}
+    ${ctaButton('Join the waitlist', ctaUrl)}
     <p style="margin: 24px 0 0; font-size: 14px; color: ${EMAIL_THEME.muted}; text-align: center;">
       Just reply if you have questions. I read every one.
     </p>`;

--- a/schemas/migrations/032_career_waitlist_optional_review_timing.sql
+++ b/schemas/migrations/032_career_waitlist_optional_review_timing.sql
@@ -1,0 +1,9 @@
+-- Career Companion Phase 0: make review_timing optional.
+--
+-- One-click email joins (signed-token links) register an email with no form,
+-- so there's no review_timing to record. The column stays for the form-based
+-- flow and so the question can be re-added later without another migration;
+-- the CHECK still constrains any non-null value to the allowed set (a CHECK
+-- passes on NULL in Postgres).
+
+ALTER TABLE career_waitlist ALTER COLUMN review_timing DROP NOT NULL;


### PR DESCRIPTION
## What & why
We mail people whose email we already know, then make them re-type it into a form — friction on the exact step we're trying to maximize. This makes the email CTA **one-click**: click → land on `/career` → auto-registered → "You're in." No form.

## How
- **Signed token** (`lib/career/waitlist-token.ts`) — a self-contained HMAC token (reuses the `UNSUBSCRIBE_SECRET`/`CRON_SECRET` chain) that encodes + signs the recipient's email. An attacker can't forge a valid token for an address they don't control, and there's no raw email in the URL.
- **Scanner-safe** — registration fires via a **JS `POST` on page load**, not a bare `GET`. Corporate email link-scanners (Mimecast/Proofpoint/Safe Links) prefetch URLs but don't run JS, so they can't create phantom joins.
- **Review-timing question dropped** (per owner call) — `/career` is now just email → Join; the API accepts an optional `review_timing`. **Migration 032** makes the column nullable (kept for the form path and easy re-add).
- **Attribution** — token path resolves `user_id` via a `profiles` lookup so joins stitch to the real user; append-only + idempotent semantics preserved; still rate-limited.

## Scope
Only affects **future sends** — the 95 emails already out keep their old (form) links.

## Testing
- New: token round-trip/tamper/forgery tests; API token-path tests (join, user resolution, invalid-token 400, idempotent re-click); form auto-join + fallback tests.
- Full suite: **1475 passing**, 0 failures. Type check clean vs. baseline. Migration 032 applied and verified (`review_timing` now nullable).

Note: the token is keyed with a server secret; prod has `CRON_SECRET`, so generation (email send) and verification (API) share the same key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added one-click career waitlist joining through secure email links.
  * Invalid links fall back to the standard email signup form.
  * Career validation emails now include personalized join links.
* **Improvements**
  * Removed the required performance review timing question from the signup form.
  * Review timing is now optional when joining the waitlist.
  * Repeat clicks on a valid join link are handled safely without duplicate confirmation events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->