### PR TITLE
CareerOtter Phase 2 · M2a — Evidence loop (data + API)

### DIFF
--- a/__tests__/api/wins.test.ts
+++ b/__tests__/api/wins.test.ts
@@ -107,10 +107,15 @@ describe("POST /api/wins", () => {
   });
 
   it("ignores a forged source and records manual", async () => {
-    adminReturning({ data: { id: "w1", text: "x", source: "manual" }, error: null });
+    const builder = adminReturning({ data: { id: "w1", text: "x", source: "manual" }, error: null });
     const res = await POST(req({ text: "x", source: "zero_to_case" }));
     expect(res.status).toBe(201);
-    // Server-authoritative provenance: the event (and insert) use "manual".
+    // Server-authoritative provenance: the persisted row uses "manual", not the
+    // forged client value.
+    expect(builder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ source: "manual" })
+    );
+    // ...and the analytics event reports the same authoritative source.
     expect(mockCapture).toHaveBeenCalledWith(
       USER.id,
       CAREEROTTER_EVENT_NAMES.WIN_LOGGED,

--- a/__tests__/api/wins.test.ts
+++ b/__tests__/api/wins.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for the wins API (CareerOtter Phase 2, M2):
+ * - auth (401), validation (missing text, bad tag, over-length), success (201)
+ * - GET lists the user's wins
+ * - PATCH/DELETE are scoped to the owner (404 when the row isn't theirs)
+ * - a server-authoritative win_logged event fires on create
+ */
+
+import { GET, POST } from "@/app/api/wins/route";
+import { PATCH, DELETE } from "@/app/api/wins/[id]/route";
+import { NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin-client";
+import { captureServerEvent } from "@/lib/analytics/posthog-server";
+import { CAREEROTTER_EVENT_NAMES } from "@/lib/analytics/careerotter-event-names";
+
+jest.mock("@/lib/supabase/server", () => ({ createClient: jest.fn() }));
+jest.mock("@/lib/supabase/admin-client", () => ({ createAdminClient: jest.fn() }));
+jest.mock("@/lib/analytics/posthog-server", () => ({
+  captureServerEvent: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock("@/lib/services/logger.service", () => ({
+  loggerService: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+// next/server (NextRequest/NextResponse/after) is mocked globally in jest.setup.js.
+
+const mockCreateClient = createClient as jest.Mock;
+const mockCreateAdminClient = createAdminClient as jest.Mock;
+const mockCapture = captureServerEvent as jest.Mock;
+
+const USER = { id: "user-1", email: "u@example.com" };
+
+function setUser(user: unknown) {
+  mockCreateClient.mockResolvedValue({
+    auth: { getUser: jest.fn().mockResolvedValue({ data: { user }, error: null }) },
+  });
+}
+
+/**
+ * Chainable Supabase-query mock: every builder method returns the builder, and
+ * the builder is awaitable (resolves to `result`). Covers both
+ * `.select().eq().order()` and `.insert().select().single()` shapes.
+ */
+function adminReturning(result: { data: unknown; error: unknown }) {
+  const builder: Record<string, unknown> = {};
+  const methods = [
+    "from", "select", "insert", "update", "delete", "eq", "order",
+    "single", "maybeSingle",
+  ];
+  for (const m of methods) builder[m] = jest.fn(() => builder);
+  (builder as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+    resolve(result);
+  mockCreateAdminClient.mockReturnValue(builder);
+  return builder;
+}
+
+function req(body: unknown, method = "POST") {
+  return new NextRequest("http://localhost:3000/api/wins", {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setUser(USER);
+});
+
+describe("POST /api/wins", () => {
+  it("401 when unauthenticated", async () => {
+    setUser(null);
+    const res = await POST(req({ text: "shipped it" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("400 when text is missing", async () => {
+    adminReturning({ data: null, error: null });
+    const res = await POST(req({ tag: "delivery" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("400 on an invalid tag", async () => {
+    adminReturning({ data: null, error: null });
+    const res = await POST(req({ text: "shipped it", tag: "wizardry" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("400 when text exceeds the cap", async () => {
+    adminReturning({ data: null, error: null });
+    const res = await POST(req({ text: "x".repeat(2001) }));
+    expect(res.status).toBe(400);
+  });
+
+  it("201 on success and fires win_logged", async () => {
+    const win = { id: "w1", text: "shipped it", tag: "delivery", source: "manual" };
+    adminReturning({ data: win, error: null });
+    const res = await POST(req({ text: "shipped it", tag: "delivery" }));
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.win).toEqual(win);
+    expect(mockCapture).toHaveBeenCalledWith(
+      USER.id,
+      CAREEROTTER_EVENT_NAMES.WIN_LOGGED,
+      expect.objectContaining({ tag: "delivery", source: "manual" })
+    );
+  });
+});
+
+describe("GET /api/wins", () => {
+  it("returns the user's wins", async () => {
+    const wins = [{ id: "w1", text: "a" }, { id: "w2", text: "b" }];
+    adminReturning({ data: wins, error: null });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect((await res.json()).wins).toEqual(wins);
+  });
+
+  it("401 when unauthenticated", async () => {
+    setUser(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("PATCH/DELETE /api/wins/:id", () => {
+  const ctx = { params: Promise.resolve({ id: "w1" }) };
+
+  it("404 when the win isn't the caller's (no row returned)", async () => {
+    adminReturning({ data: null, error: { code: "PGRST116" } });
+    const res = await PATCH(req({ text: "edited" }, "PATCH"), ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("updates an owned win", async () => {
+    const win = { id: "w1", text: "edited", tag: null, source: "manual" };
+    adminReturning({ data: win, error: null });
+    const res = await PATCH(req({ text: "edited" }, "PATCH"), ctx);
+    expect(res.status).toBe(200);
+    expect((await res.json()).win.text).toBe("edited");
+  });
+
+  it("404 deleting a win that isn't the caller's", async () => {
+    adminReturning({ data: null, error: null });
+    const res = await DELETE(req({}, "DELETE"), ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("deletes an owned win", async () => {
+    adminReturning({ data: { id: "w1" }, error: null });
+    const res = await DELETE(req({}, "DELETE"), ctx);
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+  });
+});

--- a/__tests__/api/wins.test.ts
+++ b/__tests__/api/wins.test.ts
@@ -105,6 +105,18 @@ describe("POST /api/wins", () => {
       expect.objectContaining({ tag: "delivery", source: "manual" })
     );
   });
+
+  it("ignores a forged source and records manual", async () => {
+    adminReturning({ data: { id: "w1", text: "x", source: "manual" }, error: null });
+    const res = await POST(req({ text: "x", source: "zero_to_case" }));
+    expect(res.status).toBe(201);
+    // Server-authoritative provenance: the event (and insert) use "manual".
+    expect(mockCapture).toHaveBeenCalledWith(
+      USER.id,
+      CAREEROTTER_EVENT_NAMES.WIN_LOGGED,
+      expect.objectContaining({ source: "manual" })
+    );
+  });
 });
 
 describe("GET /api/wins", () => {
@@ -138,6 +150,18 @@ describe("PATCH/DELETE /api/wins/:id", () => {
     const res = await PATCH(req({ text: "edited" }, "PATCH"), ctx);
     expect(res.status).toBe(200);
     expect((await res.json()).win.text).toBe("edited");
+  });
+
+  it("400 on a PATCH with no editable fields (no phantom edited_at bump)", async () => {
+    adminReturning({ data: null, error: null });
+    const res = await PATCH(req({}, "PATCH"), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("500 (not 404) when the PATCH hits a real DB error", async () => {
+    adminReturning({ data: null, error: { code: "08006", message: "connection failure" } });
+    const res = await PATCH(req({ text: "edited" }, "PATCH"), ctx);
+    expect(res.status).toBe(500);
   });
 
   it("404 deleting a win that isn't the caller's", async () => {

--- a/__tests__/api/zero-to-case.test.ts
+++ b/__tests__/api/zero-to-case.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for POST /api/careerotter/zero-to-case (M2 activation).
+ * - auth (401), mode validation (400)
+ * - idempotent: an already-completed profile returns the stored case and does
+ *   NOT spend another model call
+ * - success: generates via the model, returns 201, fires ztc_completed
+ */
+
+import { POST } from "@/app/api/careerotter/zero-to-case/route";
+import { NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin-client";
+import { callOpenAI } from "@/lib/openai/client";
+import { captureServerEvent } from "@/lib/analytics/posthog-server";
+import { CAREEROTTER_EVENT_NAMES } from "@/lib/analytics/careerotter-event-names";
+
+jest.mock("@/lib/supabase/server", () => ({ createClient: jest.fn() }));
+jest.mock("@/lib/supabase/admin-client", () => ({ createAdminClient: jest.fn() }));
+jest.mock("@/lib/openai/client", () => ({ callOpenAI: jest.fn() }));
+jest.mock("@/lib/analytics/posthog-server", () => ({
+  captureServerEvent: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock("@/lib/services/logger.service", () => ({
+  loggerService: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+// next/server (NextRequest/NextResponse/after) is mocked globally in jest.setup.js.
+
+const mockCreateClient = createClient as jest.Mock;
+const mockCreateAdminClient = createAdminClient as jest.Mock;
+const mockCallOpenAI = callOpenAI as jest.Mock;
+const mockCapture = captureServerEvent as jest.Mock;
+
+const USER = { id: "user-1", email: "u@example.com" };
+
+function setUser(user: unknown) {
+  mockCreateClient.mockResolvedValue({
+    auth: { getUser: jest.fn().mockResolvedValue({ data: { user }, error: null }) },
+  });
+}
+
+function adminReturning(result: { data: unknown; error: unknown }) {
+  const builder: Record<string, unknown> = {};
+  for (const m of ["from", "select", "insert", "update", "upsert", "eq", "maybeSingle", "single"]) {
+    builder[m] = jest.fn(() => builder);
+  }
+  (builder as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  mockCreateAdminClient.mockReturnValue(builder);
+}
+
+function req(body: unknown) {
+  return new NextRequest("http://localhost:3000/api/careerotter/zero-to-case", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setUser(USER);
+});
+
+it("401 when unauthenticated", async () => {
+  setUser(null);
+  const res = await POST(req({ mode: "promotion" }));
+  expect(res.status).toBe(401);
+});
+
+it("400 on an invalid mode", async () => {
+  adminReturning({ data: null, error: null });
+  const res = await POST(req({ mode: "world-domination" }));
+  expect(res.status).toBe(400);
+  expect(mockCallOpenAI).not.toHaveBeenCalled();
+});
+
+it("is idempotent: returns the stored case without a new model call", async () => {
+  adminReturning({
+    data: {
+      zero_to_case_completed_at: "2026-07-01T00:00:00Z",
+      starter_case: "stored case",
+      mode: "promotion",
+    },
+    error: null,
+  });
+  const res = await POST(req({ mode: "promotion", wins: ["a"] }));
+  expect(res.status).toBe(200);
+  const json = await res.json();
+  expect(json.starterCase).toBe("stored case");
+  expect(json.alreadyCompleted).toBe(true);
+  expect(mockCallOpenAI).not.toHaveBeenCalled();
+});
+
+it("generates a starter case, returns 201, and fires ztc_completed", async () => {
+  adminReturning({ data: null, error: null }); // no existing profile; upserts ok
+  mockCallOpenAI.mockResolvedValue("your generated starter case");
+
+  const res = await POST(
+    req({
+      mode: "raise",
+      role: "Staff Engineer",
+      review_date: "2026-09-14",
+      wins: ["shipped billing migration", "unblocked data team"],
+    })
+  );
+
+  expect(res.status).toBe(201);
+  const json = await res.json();
+  expect(json.starterCase).toBe("your generated starter case");
+  expect(json.alreadyCompleted).toBe(false);
+  expect(mockCallOpenAI).toHaveBeenCalledTimes(1);
+  expect(mockCapture).toHaveBeenCalledWith(
+    USER.id,
+    CAREEROTTER_EVENT_NAMES.ZTC_COMPLETED,
+    expect.objectContaining({ mode: "raise", wins_seeded: 2, has_review_date: true })
+  );
+});
+
+it("400 on an invalid review_date format", async () => {
+  adminReturning({ data: null, error: null });
+  const res = await POST(req({ mode: "promotion", review_date: "next tuesday" }));
+  expect(res.status).toBe(400);
+});

--- a/__tests__/api/zero-to-case.test.ts
+++ b/__tests__/api/zero-to-case.test.ts
@@ -38,13 +38,24 @@ function setUser(user: unknown) {
   });
 }
 
-function adminReturning(result: { data: unknown; error: unknown }) {
-  const builder: Record<string, unknown> = {};
-  for (const m of ["from", "select", "insert", "update", "upsert", "eq", "maybeSingle", "single"]) {
-    builder[m] = jest.fn(() => builder);
-  }
-  (builder as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
-  mockCreateAdminClient.mockReturnValue(builder);
+type OpResult = { data: unknown; error: unknown };
+function chain(result: OpResult) {
+  const b: Record<string, unknown> = {};
+  for (const m of ["select", "eq", "is", "maybeSingle", "single"]) b[m] = () => b;
+  (b as { then: unknown }).then = (res: (v: OpResult) => void) => res(result);
+  return b;
+}
+// Per-operation admin mock: the zero-to-case claim flow issues insert (claim),
+// update (claim/save), and select (stored-case fetch) with different results.
+function adminOps(ops: { insert?: OpResult; update?: OpResult; select?: OpResult }) {
+  const none: OpResult = { data: null, error: null };
+  mockCreateAdminClient.mockReturnValue({
+    from: () => ({
+      insert: () => chain(ops.insert ?? none),
+      update: () => chain(ops.update ?? none),
+      select: () => chain(ops.select ?? none),
+    }),
+  });
 }
 
 function req(body: unknown) {
@@ -67,20 +78,26 @@ it("401 when unauthenticated", async () => {
 });
 
 it("400 on an invalid mode", async () => {
-  adminReturning({ data: null, error: null });
+  adminOps({});
   const res = await POST(req({ mode: "world-domination" }));
   expect(res.status).toBe(400);
   expect(mockCallOpenAI).not.toHaveBeenCalled();
 });
 
+it("400 on a calendar-invalid review_date (2026-02-30)", async () => {
+  adminOps({});
+  const res = await POST(req({ mode: "promotion", review_date: "2026-02-30" }));
+  expect(res.status).toBe(400);
+  expect(mockCallOpenAI).not.toHaveBeenCalled();
+});
+
 it("is idempotent: returns the stored case without a new model call", async () => {
-  adminReturning({
-    data: {
-      zero_to_case_completed_at: "2026-07-01T00:00:00Z",
-      starter_case: "stored case",
-      mode: "promotion",
-    },
-    error: null,
+  // insert conflicts (row exists), claim-update flips nothing (already complete),
+  // then the stored case is returned.
+  adminOps({
+    insert: { data: null, error: { code: "23505" } },
+    update: { data: null, error: null },
+    select: { data: { starter_case: "stored case" }, error: null },
   });
   const res = await POST(req({ mode: "promotion", wins: ["a"] }));
   expect(res.status).toBe(200);
@@ -91,7 +108,11 @@ it("is idempotent: returns the stored case without a new model call", async () =
 });
 
 it("generates a starter case, returns 201, and fires ztc_completed", async () => {
-  adminReturning({ data: null, error: null }); // no existing profile; upserts ok
+  // insert claims the run (row created); save-update succeeds.
+  adminOps({
+    insert: { data: { user_id: "user-1" }, error: null },
+    update: { data: null, error: null },
+  });
   mockCallOpenAI.mockResolvedValue("your generated starter case");
 
   const res = await POST(
@@ -116,7 +137,7 @@ it("generates a starter case, returns 201, and fires ztc_completed", async () =>
 });
 
 it("400 on an invalid review_date format", async () => {
-  adminReturning({ data: null, error: null });
+  adminOps({});
   const res = await POST(req({ mode: "promotion", review_date: "next tuesday" }));
   expect(res.status).toBe(400);
 });

--- a/__tests__/constants/careerotter.test.ts
+++ b/__tests__/constants/careerotter.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Guards lib/constants/careerotter.ts against drift from the SQL CHECK lists in
+ * schemas/migrations/032_careerotter_evidence.sql. If someone changes a CHECK in
+ * the migration without updating the constant (or vice versa), this fails.
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+import {
+  CAREER_MODES,
+  WIN_TAGS,
+  WIN_SOURCES,
+  CAREER_MODE_OPTIONS,
+  WIN_TAG_OPTIONS,
+} from "@/lib/constants/careerotter";
+
+const migration = readFileSync(
+  join(process.cwd(), "schemas/migrations/032_careerotter_evidence.sql"),
+  "utf8"
+);
+
+/** Pull the values out of `check (<col> in ('a', 'b', ...))` for a column. */
+function checkValues(column: string): string[] {
+  const re = new RegExp(`check \\(${column} in \\(([^)]*)\\)`, "i");
+  const m = migration.match(re);
+  if (!m) throw new Error(`no CHECK found for ${column}`);
+  return Array.from(m[1].matchAll(/'([^']+)'/g)).map((x) => x[1]);
+}
+
+describe("careerotter constants mirror the SQL CHECK lists", () => {
+  it("CAREER_MODES matches career_profiles.mode", () => {
+    expect([...CAREER_MODES].sort()).toEqual(checkValues("mode").sort());
+  });
+
+  it("WIN_TAGS matches wins.tag", () => {
+    expect([...WIN_TAGS].sort()).toEqual(checkValues("tag").sort());
+  });
+
+  it("WIN_SOURCES matches wins.source", () => {
+    expect([...WIN_SOURCES].sort()).toEqual(checkValues("source").sort());
+  });
+});
+
+describe("option lists stay aligned with their value lists", () => {
+  it("mode options cover every mode", () => {
+    expect(CAREER_MODE_OPTIONS.map((o) => o.value).sort()).toEqual(
+      [...CAREER_MODES].sort()
+    );
+  });
+
+  it("tag options cover every tag", () => {
+    expect(WIN_TAG_OPTIONS.map((o) => o.value).sort()).toEqual(
+      [...WIN_TAGS].sort()
+    );
+  });
+});

--- a/app/api/careerotter/zero-to-case/route.ts
+++ b/app/api/careerotter/zero-to-case/route.ts
@@ -24,6 +24,8 @@ import { LogCategory } from "@/lib/services/logger.types";
 
 export const maxDuration = 60;
 
+const PG_UNIQUE_VIOLATION = "23505";
+
 type Body = {
   mode?: unknown;
   role?: unknown;
@@ -35,6 +37,19 @@ type Body = {
 };
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+// Regex alone accepts calendar-invalid values like 2026-02-30; round-trip the
+// parsed components to reject them (a bare `new Date` silently rolls over).
+function isValidCalendarDate(s: string): boolean {
+  if (!ISO_DATE.test(s)) return false;
+  const [y, m, d] = s.split("-").map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  return (
+    dt.getUTCFullYear() === y &&
+    dt.getUTCMonth() === m - 1 &&
+    dt.getUTCDate() === d
+  );
+}
 
 function str(v: unknown, max = 300): string | null {
   if (typeof v !== "string") return null;
@@ -104,9 +119,9 @@ export async function POST(request: NextRequest) {
   const target = str(body.target, 500);
   let reviewDate: string | null = null;
   if (body.review_date != null && body.review_date !== "") {
-    if (typeof body.review_date !== "string" || !ISO_DATE.test(body.review_date)) {
+    if (typeof body.review_date !== "string" || !isValidCalendarDate(body.review_date)) {
       return NextResponse.json(
-        { error: "review_date must be YYYY-MM-DD" },
+        { error: "review_date must be a valid YYYY-MM-DD date" },
         { status: 400 }
       );
     }
@@ -121,23 +136,61 @@ export async function POST(request: NextRequest) {
     : [];
 
   const admin = createAdminClient();
+  const nowIso = new Date().toISOString();
+  const goalFrame = {
+    mode: mode as CareerMode,
+    role,
+    level,
+    time_in_role: timeInRole,
+    target,
+    review_date: reviewDate,
+    updated_at: nowIso,
+  };
 
-  // Idempotent: if already completed, return the stored case (no second call).
-  const { data: existing } = await admin
+  // Atomically claim the one free Zero-to-Case run so two concurrent requests
+  // can't both spend a model call and seed duplicate wins. Either we create the
+  // row already-claimed, or we flip an existing row's completed_at from null.
+  let claimed = false;
+  const insert = await admin
     .from("career_profiles")
-    .select("zero_to_case_completed_at, starter_case, mode")
-    .eq("user_id", user.id)
+    .insert({ user_id: user.id, ...goalFrame, zero_to_case_completed_at: nowIso })
+    .select("user_id")
     .maybeSingle();
+  if (!insert.error) {
+    claimed = true;
+  } else if (insert.error.code === PG_UNIQUE_VIOLATION) {
+    const claim = await admin
+      .from("career_profiles")
+      .update({ ...goalFrame, zero_to_case_completed_at: nowIso })
+      .eq("user_id", user.id)
+      .is("zero_to_case_completed_at", null)
+      .select("user_id")
+      .maybeSingle();
+    claimed = Boolean(claim.data);
+  } else {
+    loggerService.error("Failed to claim career profile", insert.error, {
+      category: LogCategory.DATABASE,
+      userId: user.id,
+      action: "career_profile_claim_failed",
+    });
+    return NextResponse.json({ error: "Failed to save your case" }, { status: 500 });
+  }
 
-  if (existing?.zero_to_case_completed_at && existing.starter_case) {
+  if (!claimed) {
+    // Already completed by a prior/concurrent run — return the stored case.
+    const { data: existing } = await admin
+      .from("career_profiles")
+      .select("starter_case")
+      .eq("user_id", user.id)
+      .maybeSingle();
     return NextResponse.json({
-      starterCase: existing.starter_case,
+      starterCase: existing?.starter_case ?? "",
       alreadyCompleted: true,
     });
   }
 
-  // Generate the starter case. If the model call fails, still persist the goal
-  // frame so onboarding isn't lost — the user can generate later.
+  // We own the claim. Generate the case; on failure, release the claim so the
+  // user can retry rather than being permanently marked complete with no case.
   let starterCase = "";
   try {
     starterCase = await callOpenAI({
@@ -164,34 +217,25 @@ export async function POST(request: NextRequest) {
       userId: user.id,
       action: "ztc_generation_failed",
     });
+    await admin
+      .from("career_profiles")
+      .update({ zero_to_case_completed_at: null })
+      .eq("user_id", user.id);
     return NextResponse.json(
       { error: "Could not generate your case right now. Please try again." },
       { status: 502 }
     );
   }
 
-  const nowIso = new Date().toISOString();
-  const { error: upsertError } = await admin.from("career_profiles").upsert(
-    {
-      user_id: user.id,
-      mode: mode as CareerMode,
-      role,
-      level,
-      time_in_role: timeInRole,
-      target,
-      review_date: reviewDate,
-      zero_to_case_completed_at: nowIso,
-      starter_case: starterCase,
-      updated_at: nowIso,
-    },
-    { onConflict: "user_id" }
-  );
-
-  if (upsertError) {
-    loggerService.error("Failed to save career profile", upsertError, {
+  const { error: saveError } = await admin
+    .from("career_profiles")
+    .update({ starter_case: starterCase, updated_at: new Date().toISOString() })
+    .eq("user_id", user.id);
+  if (saveError) {
+    loggerService.error("Failed to save starter case", saveError, {
       category: LogCategory.DATABASE,
       userId: user.id,
-      action: "career_profile_upsert_failed",
+      action: "career_profile_save_failed",
     });
     return NextResponse.json({ error: "Failed to save your case" }, { status: 500 });
   }

--- a/app/api/careerotter/zero-to-case/route.ts
+++ b/app/api/careerotter/zero-to-case/route.ts
@@ -1,0 +1,219 @@
+/**
+ * Zero to Case — onboarding (CareerOtter Phase 2, M2).
+ *
+ * POST /api/careerotter/zero-to-case
+ *
+ * Three questions in, a starter promo case out. The AI restructures what the
+ * user already remembers into evidence language, names the obvious gap, and
+ * states one next step, so they leave day one with a real document, not an empty
+ * journal. This is the ONE free model call at onboarding (like the roast) — the
+ * strict AI/Pro line resumes immediately after. Idempotent: once completed, it
+ * returns the stored case without spending another call.
+ */
+
+import { type NextRequest, NextResponse, after } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin-client";
+import { callOpenAI } from "@/lib/openai/client";
+import { VOICE_GUARDRAILS } from "@/lib/ai/voice-guardrails";
+import { CAREER_MODES, type CareerMode } from "@/lib/constants/careerotter";
+import { CAREEROTTER_EVENT_NAMES } from "@/lib/analytics/careerotter-event-names";
+import { captureServerEvent } from "@/lib/analytics/posthog-server";
+import { loggerService } from "@/lib/services/logger.service";
+import { LogCategory } from "@/lib/services/logger.types";
+
+export const maxDuration = 60;
+
+type Body = {
+  mode?: unknown;
+  role?: unknown;
+  level?: unknown;
+  time_in_role?: unknown;
+  target?: unknown;
+  review_date?: unknown;
+  wins?: unknown;
+};
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+function str(v: unknown, max = 300): string | null {
+  if (typeof v !== "string") return null;
+  const t = v.trim();
+  return t ? t.slice(0, max) : null;
+}
+
+function buildPrompt(input: {
+  mode: CareerMode;
+  role: string | null;
+  level: string | null;
+  target: string | null;
+  reviewDate: string | null;
+  wins: string[];
+}): string {
+  const goal =
+    input.mode === "job_search"
+      ? "landing a better role"
+      : input.mode === "raise"
+        ? "a raise"
+        : "a promotion";
+  const lines = [
+    `The user is working toward ${goal}.`,
+    input.role ? `Role/level: ${input.role}${input.level ? `, ${input.level}` : ""}.` : "",
+    input.target ? `Target: ${input.target}.` : "",
+    input.reviewDate ? `Next review date: ${input.reviewDate}.` : "",
+    "",
+    "Things they shipped or fixed recently:",
+    ...input.wins.map((w, i) => `${i + 1}. ${w}`),
+    "",
+    "Draft a short starter case (200-350 words):",
+    "- Restructure their wins into evidence language: situation, action, measurable result where possible.",
+    "- Name the single most obvious gap in their case so far.",
+    "- End with one concrete next step to take before their review.",
+    "Write it in the user's own voice, first person, no otter personality. This is their document.",
+  ];
+  return lines.filter(Boolean).join("\n");
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Body;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  // mode — required, one of the fork options.
+  const mode = body.mode;
+  if (!(CAREER_MODES as readonly string[]).includes(mode as string)) {
+    return NextResponse.json(
+      { error: `mode must be one of: ${CAREER_MODES.join(", ")}` },
+      { status: 400 }
+    );
+  }
+  const role = str(body.role);
+  const level = str(body.level, 120);
+  const timeInRole = str(body.time_in_role, 120);
+  const target = str(body.target, 500);
+  let reviewDate: string | null = null;
+  if (body.review_date != null && body.review_date !== "") {
+    if (typeof body.review_date !== "string" || !ISO_DATE.test(body.review_date)) {
+      return NextResponse.json(
+        { error: "review_date must be YYYY-MM-DD" },
+        { status: 400 }
+      );
+    }
+    reviewDate = body.review_date;
+  }
+
+  const winsInput = Array.isArray(body.wins)
+    ? body.wins
+        .filter((w): w is string => typeof w === "string" && w.trim().length > 0)
+        .map((w) => w.trim().slice(0, 2000))
+        .slice(0, 3)
+    : [];
+
+  const admin = createAdminClient();
+
+  // Idempotent: if already completed, return the stored case (no second call).
+  const { data: existing } = await admin
+    .from("career_profiles")
+    .select("zero_to_case_completed_at, starter_case, mode")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (existing?.zero_to_case_completed_at && existing.starter_case) {
+    return NextResponse.json({
+      starterCase: existing.starter_case,
+      alreadyCompleted: true,
+    });
+  }
+
+  // Generate the starter case. If the model call fails, still persist the goal
+  // frame so onboarding isn't lost — the user can generate later.
+  let starterCase = "";
+  try {
+    starterCase = await callOpenAI({
+      systemPrompt: VOICE_GUARDRAILS,
+      messages: [
+        {
+          role: "user",
+          content: buildPrompt({
+            mode: mode as CareerMode,
+            role,
+            level,
+            target,
+            reviewDate,
+            wins: winsInput,
+          }),
+        },
+      ],
+      maxTokens: 800,
+      temperature: 0.6,
+    });
+  } catch (error) {
+    loggerService.error("Zero to Case generation failed", error, {
+      category: LogCategory.AI_SERVICE,
+      userId: user.id,
+      action: "ztc_generation_failed",
+    });
+    return NextResponse.json(
+      { error: "Could not generate your case right now. Please try again." },
+      { status: 502 }
+    );
+  }
+
+  const nowIso = new Date().toISOString();
+  const { error: upsertError } = await admin.from("career_profiles").upsert(
+    {
+      user_id: user.id,
+      mode: mode as CareerMode,
+      role,
+      level,
+      time_in_role: timeInRole,
+      target,
+      review_date: reviewDate,
+      zero_to_case_completed_at: nowIso,
+      starter_case: starterCase,
+      updated_at: nowIso,
+    },
+    { onConflict: "user_id" }
+  );
+
+  if (upsertError) {
+    loggerService.error("Failed to save career profile", upsertError, {
+      category: LogCategory.DATABASE,
+      userId: user.id,
+      action: "career_profile_upsert_failed",
+    });
+    return NextResponse.json({ error: "Failed to save your case" }, { status: 500 });
+  }
+
+  // Seed the wins log from the answers so the tracker isn't empty on day one.
+  if (winsInput.length > 0) {
+    await admin.from("wins").insert(
+      winsInput.map((text) => ({
+        user_id: user.id,
+        text,
+        source: "zero_to_case" as const,
+      }))
+    );
+  }
+
+  after(
+    captureServerEvent(user.id, CAREEROTTER_EVENT_NAMES.ZTC_COMPLETED, {
+      mode,
+      wins_seeded: winsInput.length,
+      has_review_date: Boolean(reviewDate),
+    })
+  );
+
+  return NextResponse.json({ starterCase, alreadyCompleted: false }, { status: 201 });
+}

--- a/app/api/wins/[id]/route.ts
+++ b/app/api/wins/[id]/route.ts
@@ -1,0 +1,150 @@
+/**
+ * Wins API — edit / delete a single win (CareerOtter Phase 2, M2).
+ *
+ * PATCH  /api/wins/:id   edit text / impact_number / tag (sets edited_at)
+ * DELETE /api/wins/:id   remove a win
+ *
+ * Every mutation is scoped to the session user_id, so the service-role admin
+ * client can only ever touch the caller's own rows.
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin-client";
+import { WIN_TAGS, WIN_LIMITS, type WinTag } from "@/lib/constants/careerotter";
+import { loggerService } from "@/lib/services/logger.service";
+import { LogCategory } from "@/lib/services/logger.types";
+
+type PatchBody = {
+  text?: unknown;
+  impact_number?: unknown;
+  tag?: unknown;
+};
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: PatchBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const update: {
+    text?: string;
+    impact_number?: string | null;
+    tag?: WinTag | null;
+    edited_at: string;
+  } = { edited_at: new Date().toISOString() };
+
+  if (body.text !== undefined) {
+    const text = typeof body.text === "string" ? body.text.trim() : "";
+    if (!text) {
+      return NextResponse.json({ error: "Win text is required" }, { status: 400 });
+    }
+    if (text.length > WIN_LIMITS.textMax) {
+      return NextResponse.json(
+        { error: `Win text must be ${WIN_LIMITS.textMax} characters or fewer` },
+        { status: 400 }
+      );
+    }
+    update.text = text;
+  }
+
+  if (body.impact_number !== undefined) {
+    if (body.impact_number === null || body.impact_number === "") {
+      update.impact_number = null;
+    } else if (typeof body.impact_number === "string") {
+      update.impact_number = body.impact_number
+        .trim()
+        .slice(0, WIN_LIMITS.impactNumberMax);
+    } else {
+      return NextResponse.json(
+        { error: "impact_number must be a string" },
+        { status: 400 }
+      );
+    }
+  }
+
+  if (body.tag !== undefined) {
+    if (body.tag === null || body.tag === "") {
+      update.tag = null;
+    } else if ((WIN_TAGS as readonly string[]).includes(body.tag as string)) {
+      update.tag = body.tag as WinTag;
+    } else {
+      return NextResponse.json({ error: "Invalid tag" }, { status: 400 });
+    }
+  }
+
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("wins")
+    .update(update)
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .select("id, text, impact_number, tag, source, created_at, edited_at")
+    .single();
+
+  if (error || !data) {
+    // No row (wrong id or not the owner) surfaces as 404, not 500.
+    if (error?.code === "PGRST116" || !data) {
+      return NextResponse.json({ error: "Win not found" }, { status: 404 });
+    }
+    loggerService.error("Failed to update win", error, {
+      category: LogCategory.DATABASE,
+      userId: user.id,
+      action: "win_update_failed",
+    });
+    return NextResponse.json({ error: "Failed to update win" }, { status: 500 });
+  }
+
+  return NextResponse.json({ win: data });
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("wins")
+    .delete()
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .select("id")
+    .maybeSingle();
+
+  if (error) {
+    loggerService.error("Failed to delete win", error, {
+      category: LogCategory.DATABASE,
+      userId: user.id,
+      action: "win_delete_failed",
+    });
+    return NextResponse.json({ error: "Failed to delete win" }, { status: 500 });
+  }
+  if (!data) {
+    return NextResponse.json({ error: "Win not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/wins/[id]/route.ts
+++ b/app/api/wins/[id]/route.ts
@@ -87,6 +87,19 @@ export async function PATCH(
     }
   }
 
+  // A PATCH with no editable field would still bump edited_at, recording an edit
+  // that never happened. Reject it.
+  if (
+    update.text === undefined &&
+    update.impact_number === undefined &&
+    update.tag === undefined
+  ) {
+    return NextResponse.json(
+      { error: "No editable fields provided" },
+      { status: 400 }
+    );
+  }
+
   const admin = createAdminClient();
   const { data, error } = await admin
     .from("wins")
@@ -96,9 +109,11 @@ export async function PATCH(
     .select("id, text, impact_number, tag, source, created_at, edited_at")
     .single();
 
-  if (error || !data) {
-    // No row (wrong id or not the owner) surfaces as 404, not 500.
-    if (error?.code === "PGRST116" || !data) {
+  // Handle real DB errors before the not-found branch, so a genuine failure
+  // isn't masked as 404 (errors generally arrive with data: null).
+  if (error) {
+    if (error.code === "PGRST116") {
+      // No row matched: wrong id or not the caller's win.
       return NextResponse.json({ error: "Win not found" }, { status: 404 });
     }
     loggerService.error("Failed to update win", error, {
@@ -107,6 +122,9 @@ export async function PATCH(
       action: "win_update_failed",
     });
     return NextResponse.json({ error: "Failed to update win" }, { status: 500 });
+  }
+  if (!data) {
+    return NextResponse.json({ error: "Win not found" }, { status: 404 });
   }
 
   return NextResponse.json({ win: data });

--- a/app/api/wins/route.ts
+++ b/app/api/wins/route.ts
@@ -15,7 +15,6 @@ import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin-client";
 import {
   WIN_TAGS,
-  WIN_SOURCES,
   WIN_LIMITS,
   type WinTag,
   type WinSource,
@@ -58,7 +57,6 @@ type PostBody = {
   text?: unknown;
   impact_number?: unknown;
   tag?: unknown;
-  source?: unknown;
 };
 
 export async function POST(request: NextRequest) {
@@ -110,14 +108,10 @@ export async function POST(request: NextRequest) {
     tag = body.tag as WinTag;
   }
 
-  // source — optional, defaults to manual (the capture bar).
-  let source: WinSource = "manual";
-  if (body.source != null && body.source !== "") {
-    if (!(WIN_SOURCES as readonly string[]).includes(body.source as string)) {
-      return NextResponse.json({ error: "Invalid source" }, { status: 400 });
-    }
-    source = body.source as WinSource;
-  }
+  // Provenance is server-authoritative: this manual endpoint always records
+  // "manual". Client-supplied `source` is ignored so callers can't forge
+  // "zero_to_case"/"recap"/"import".
+  const source: WinSource = "manual";
 
   const admin = createAdminClient();
   const { data, error } = await admin

--- a/app/api/wins/route.ts
+++ b/app/api/wins/route.ts
@@ -1,0 +1,153 @@
+/**
+ * Wins API — the evidence log (CareerOtter Phase 2, M2).
+ *
+ * GET  /api/wins        list the current user's wins (newest first)
+ * POST /api/wins        log a win
+ *
+ * Logging is FREE and calls no model (habit before payment, PRD M2). Auth is the
+ * session user; writes go through the service-role admin client because the wins
+ * table is RLS service-role-only, and every query is scoped to the session
+ * user_id so the admin client can't leak across users.
+ */
+
+import { type NextRequest, NextResponse, after } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin-client";
+import {
+  WIN_TAGS,
+  WIN_SOURCES,
+  WIN_LIMITS,
+  type WinTag,
+  type WinSource,
+} from "@/lib/constants/careerotter";
+import { CAREEROTTER_EVENT_NAMES } from "@/lib/analytics/careerotter-event-names";
+import { captureServerEvent } from "@/lib/analytics/posthog-server";
+import { emailDistinctId } from "@/lib/analytics/anonymize";
+import { loggerService } from "@/lib/services/logger.service";
+import { LogCategory } from "@/lib/services/logger.types";
+
+export async function GET() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("wins")
+    .select("id, text, impact_number, tag, source, created_at, edited_at")
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    loggerService.error("Failed to list wins", error, {
+      category: LogCategory.DATABASE,
+      userId: user.id,
+      action: "wins_list_failed",
+    });
+    return NextResponse.json({ error: "Failed to load wins" }, { status: 500 });
+  }
+
+  return NextResponse.json({ wins: data ?? [] });
+}
+
+type PostBody = {
+  text?: unknown;
+  impact_number?: unknown;
+  tag?: unknown;
+  source?: unknown;
+};
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: PostBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  // text — required, trimmed, capped.
+  const text = typeof body.text === "string" ? body.text.trim() : "";
+  if (!text) {
+    return NextResponse.json({ error: "Win text is required" }, { status: 400 });
+  }
+  if (text.length > WIN_LIMITS.textMax) {
+    return NextResponse.json(
+      { error: `Win text must be ${WIN_LIMITS.textMax} characters or fewer` },
+      { status: 400 }
+    );
+  }
+
+  // impact_number — optional, trimmed, capped.
+  let impactNumber: string | null = null;
+  if (body.impact_number != null && body.impact_number !== "") {
+    if (typeof body.impact_number !== "string") {
+      return NextResponse.json(
+        { error: "impact_number must be a string" },
+        { status: 400 }
+      );
+    }
+    impactNumber = body.impact_number.trim().slice(0, WIN_LIMITS.impactNumberMax);
+  }
+
+  // tag — optional, must be one of the four impact areas.
+  let tag: WinTag | null = null;
+  if (body.tag != null && body.tag !== "") {
+    if (!(WIN_TAGS as readonly string[]).includes(body.tag as string)) {
+      return NextResponse.json({ error: "Invalid tag" }, { status: 400 });
+    }
+    tag = body.tag as WinTag;
+  }
+
+  // source — optional, defaults to manual (the capture bar).
+  let source: WinSource = "manual";
+  if (body.source != null && body.source !== "") {
+    if (!(WIN_SOURCES as readonly string[]).includes(body.source as string)) {
+      return NextResponse.json({ error: "Invalid source" }, { status: 400 });
+    }
+    source = body.source as WinSource;
+  }
+
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("wins")
+    .insert({
+      user_id: user.id,
+      text,
+      impact_number: impactNumber,
+      tag,
+      source,
+    })
+    .select("id, text, impact_number, tag, source, created_at, edited_at")
+    .single();
+
+  if (error) {
+    loggerService.error("Failed to log win", error, {
+      category: LogCategory.DATABASE,
+      userId: user.id,
+      action: "win_log_failed",
+    });
+    return NextResponse.json({ error: "Failed to log win" }, { status: 500 });
+  }
+
+  // Server-authoritative win_logged. Distinct id is the user id; best-effort.
+  after(
+    captureServerEvent(user.id ?? emailDistinctId(user.email ?? ""), CAREEROTTER_EVENT_NAMES.WIN_LOGGED, {
+      tag: tag ?? "untagged",
+      source,
+    })
+  );
+
+  return NextResponse.json({ win: data }, { status: 201 });
+}

--- a/lib/ai/voice-guardrails.ts
+++ b/lib/ai/voice-guardrails.ts
@@ -1,0 +1,26 @@
+/**
+ * CareerOtter voice guardrails — the "never writes like AI" rules from the brand
+ * guide §3.2, as a single versioned prompt fragment. Import this into EVERY
+ * model-facing prompt (coach, roast, weekly recap, case builder, Zero to Case)
+ * so the banned-construction list lives in exactly one place (brand guide §7:
+ * "the rules only work if they're enforced in the actual LLM prompts").
+ *
+ * Bump VOICE_GUARDRAILS_VERSION whenever the text changes so prompt versions are
+ * diffable and eval runs can be attributed.
+ */
+
+export const VOICE_GUARDRAILS_VERSION = "1.0.0";
+
+export const VOICE_GUARDRAILS = `You are CareerOtter: a sharp friend who works in the user's industry and wants them to get paid. Dry, concrete, on the user's side. Warmth comes from being useful and right, never from soft language.
+
+Write like a person who is good at their job talking to a peer. Never like a chatbot being helpful. Hard rules — any output that trips one must be rewritten:
+- No em dashes. Use a period or a comma, or split the sentence.
+- No "it's not X, it's Y" / "not just X, but Y" / "isn't about X, it's about Y", and no two-beat reversals ("that's not a vibe, it's a number"). Say the point straight.
+- No "let's dive in", "let's unpack", "deep dive", "unlock", "supercharge", "elevate", "empower", "leverage", "streamline", "seamless", "robust", "holistic", "navigate", "delve", "realm", "tapestry", "landscape", "in today's world".
+- No rule-of-three padding for cadence ("clear, concise, and compelling"). If two of three are filler, cut them.
+- No hedging throat-clears ("it's worth noting", "it's important to remember", "keep in mind", "at the end of the day").
+- No reflexive validation ("great question", "you're absolutely right", "spot on"). Do not flatter.
+- No "as an AI" / "I'm just an AI".
+- No emoji as punctuation. No title-case cheerfulness ("Time to Crush Your Review!").
+
+Prefer short declaratives and fragments. For emphasis use a specific fact, not an intensifier ("you're 11% under market", not "significantly underpaid"). Every hard truth ships with the next action — never leave the user with a problem and no next step.`;

--- a/lib/analytics/careerotter-event-names.ts
+++ b/lib/analytics/careerotter-event-names.ts
@@ -1,0 +1,23 @@
+/**
+ * Raw CareerOtter Phase 2 event-name strings.
+ *
+ * Framework-agnostic (no "use client", no imports) so both the client hook
+ * module (careerotter-events.ts) and server routes (zero-to-case, recap cron)
+ * share one source of truth. All events use `filterTestAccounts: true` at query
+ * time (PRD §5). PostHog project 55190.
+ */
+export const CAREEROTTER_EVENT_NAMES = {
+  // Onboarding (Zero to Case)
+  ZTC_STARTED: "ztc_started",
+  ZTC_COMPLETED: "ztc_completed",
+  // The evidence loop
+  WIN_LOGGED: "win_logged",
+  RECAP_OPENED: "recap_opened",
+  // Later milestones
+  COACH_MESSAGE_SENT: "coach_message_sent",
+  CASE_EXPORTED: "case_exported",
+  COMP_ENTERED: "comp_entered",
+} as const;
+
+export type CareerotterEventName =
+  (typeof CAREEROTTER_EVENT_NAMES)[keyof typeof CAREEROTTER_EVENT_NAMES];

--- a/lib/analytics/careerotter-events.ts
+++ b/lib/analytics/careerotter-events.ts
@@ -1,7 +1,9 @@
 /**
  * CareerOtter Phase 2 analytics — client-side track helpers for the evidence
  * loop. Server-fired events (win_logged from the API, ztc_completed, recap
- * generation) use the raw names from careerotter-event-names.ts directly.
+ * generation) use the raw names from careerotter-event-names.ts directly and
+ * intentionally have no client helper here, so a capture-bar submission can't
+ * emit a duplicate, indistinguishable copy of the server-authoritative event.
  */
 
 import { capturePostHogEvent } from "./posthog";
@@ -12,11 +14,6 @@ export const CAREEROTTER_EVENTS = CAREEROTTER_EVENT_NAMES;
 /** Zero to Case onboarding started (first question shown). */
 export function trackZeroToCaseStarted(props: { mode?: string } = {}) {
   capturePostHogEvent(CAREEROTTER_EVENTS.ZTC_STARTED, props);
-}
-
-/** A win was logged from the capture bar. Server also records this authoritatively. */
-export function trackWinLogged(props: { tag?: string; source?: string } = {}) {
-  capturePostHogEvent(CAREEROTTER_EVENTS.WIN_LOGGED, props);
 }
 
 /** The user opened their weekly recap (in-app or from the email link). */

--- a/lib/analytics/careerotter-events.ts
+++ b/lib/analytics/careerotter-events.ts
@@ -1,0 +1,25 @@
+/**
+ * CareerOtter Phase 2 analytics — client-side track helpers for the evidence
+ * loop. Server-fired events (win_logged from the API, ztc_completed, recap
+ * generation) use the raw names from careerotter-event-names.ts directly.
+ */
+
+import { capturePostHogEvent } from "./posthog";
+import { CAREEROTTER_EVENT_NAMES } from "./careerotter-event-names";
+
+export const CAREEROTTER_EVENTS = CAREEROTTER_EVENT_NAMES;
+
+/** Zero to Case onboarding started (first question shown). */
+export function trackZeroToCaseStarted(props: { mode?: string } = {}) {
+  capturePostHogEvent(CAREEROTTER_EVENTS.ZTC_STARTED, props);
+}
+
+/** A win was logged from the capture bar. Server also records this authoritatively. */
+export function trackWinLogged(props: { tag?: string; source?: string } = {}) {
+  capturePostHogEvent(CAREEROTTER_EVENTS.WIN_LOGGED, props);
+}
+
+/** The user opened their weekly recap (in-app or from the email link). */
+export function trackRecapOpened(props: { week_start?: string } = {}) {
+  capturePostHogEvent(CAREEROTTER_EVENTS.RECAP_OPENED, props);
+}

--- a/lib/constants/careerotter.ts
+++ b/lib/constants/careerotter.ts
@@ -1,0 +1,47 @@
+/**
+ * CareerOtter Phase 2 (M2) shared constants — single source of truth mirrored by
+ * the SQL CHECK lists in schemas/migrations/032_careerotter_evidence.sql. Keep
+ * these in sync; __tests__ guards against drift.
+ */
+
+// The onboarding fork (RFC §2): one question routes the experience. Same data
+// model underneath, different UI emphasis.
+export const CAREER_MODES = ["promotion", "raise", "job_search"] as const;
+export type CareerMode = (typeof CAREER_MODES)[number];
+
+export const CAREER_MODE_OPTIONS: { value: CareerMode; label: string }[] = [
+  { value: "promotion", label: "A promotion" },
+  { value: "raise", label: "A raise" },
+  { value: "job_search", label: "A new job" },
+];
+
+// The four impact areas the coverage meter balances. Order is the display order.
+export const WIN_TAGS = [
+  "delivery",
+  "leadership",
+  "collaboration",
+  "craft",
+] as const;
+export type WinTag = (typeof WIN_TAGS)[number];
+
+export const WIN_TAG_OPTIONS: { value: WinTag; label: string }[] = [
+  { value: "delivery", label: "Delivery" },
+  { value: "leadership", label: "Leadership" },
+  { value: "collaboration", label: "Collaboration" },
+  { value: "craft", label: "Craft" },
+];
+
+// Where a win came from (provenance). "manual" is the capture bar.
+export const WIN_SOURCES = [
+  "manual",
+  "recap",
+  "zero_to_case",
+  "import",
+] as const;
+export type WinSource = (typeof WIN_SOURCES)[number];
+
+// Field caps enforced by the API before insert.
+export const WIN_LIMITS = {
+  textMax: 2000,
+  impactNumberMax: 120,
+} as const;

--- a/schemas/migrations/032_careerotter_evidence.sql
+++ b/schemas/migrations/032_careerotter_evidence.sql
@@ -48,7 +48,7 @@ create index if not exists wins_user_created_idx
 create table if not exists public.weekly_recaps (
   id uuid primary key default gen_random_uuid (),
   user_id uuid not null references public.profiles (id) on delete cascade,
-  week_start date not null,
+  week_start date not null check (extract(isodow from week_start) = 1),
   generated_text text,
   wins_included int not null default 0,
   created_at timestamptz not null default now(),

--- a/schemas/migrations/032_careerotter_evidence.sql
+++ b/schemas/migrations/032_careerotter_evidence.sql
@@ -1,0 +1,70 @@
+-- CareerOtter Phase 2 (M2) — the evidence loop.
+-- Three tables: the goal frame (career_profiles), the wins log (wins), and the
+-- generated Friday summaries (weekly_recaps). All service-role only per
+-- CLAUDE.md rule 4 (API-route access exclusively); RLS enabled with no policies
+-- so anon/auth clients cannot read or write directly.
+--
+-- Constants that mirror these CHECK lists live in lib/constants/careerotter.ts.
+
+-- ── career_profiles ────────────────────────────────────────────────────────
+-- One row per user: the target the whole experience structures around. The
+-- onboarding "fork" (RFC) is `mode`; job_search reuses the same data model.
+create table if not exists public.career_profiles (
+  user_id uuid primary key references public.profiles (id) on delete cascade,
+  mode text not null default 'promotion'
+    check (mode in ('promotion', 'raise', 'job_search')),
+  role text,
+  level text,
+  time_in_role text,
+  target text,
+  review_date date,
+  zero_to_case_completed_at timestamptz,
+  starter_case text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- ── wins ───────────────────────────────────────────────────────────────────
+-- The evidence log. Logging is free and calls no model (habit before payment).
+-- `tag` is one of the four impact areas the coverage meter balances.
+create table if not exists public.wins (
+  id uuid primary key default gen_random_uuid (),
+  user_id uuid not null references public.profiles (id) on delete cascade,
+  text text not null,
+  impact_number text,
+  tag text check (tag in ('delivery', 'leadership', 'collaboration', 'craft')),
+  source text not null default 'manual'
+    check (source in ('manual', 'recap', 'zero_to_case', 'import')),
+  created_at timestamptz not null default now(),
+  edited_at timestamptz
+);
+
+create index if not exists wins_user_created_idx
+  on public.wins (user_id, created_at desc);
+
+-- ── weekly_recaps ──────────────────────────────────────────────────────────
+-- One generated recap per user per week (the Friday return hook). week_start is
+-- the Monday of the recap's week; unique per user so the cron is idempotent.
+create table if not exists public.weekly_recaps (
+  id uuid primary key default gen_random_uuid (),
+  user_id uuid not null references public.profiles (id) on delete cascade,
+  week_start date not null,
+  generated_text text,
+  wins_included int not null default 0,
+  created_at timestamptz not null default now(),
+  unique (user_id, week_start)
+);
+
+create index if not exists weekly_recaps_user_idx
+  on public.weekly_recaps (user_id, week_start desc);
+
+-- ── updated_at trigger on career_profiles ──────────────────────────────────
+create trigger handle_updated_at before update on public.career_profiles
+  for each row execute function handle_updated_at ();
+
+-- ── RLS: service-role only ─────────────────────────────────────────────────
+alter table public.career_profiles enable row level security;
+alter table public.wins enable row level security;
+alter table public.weekly_recaps enable row level security;
+-- Intentionally no policies: only the service-role key (used by API routes)
+-- bypasses RLS. Client access is denied by default.

--- a/schemas/migrations/034_weekly_recap_week_start_check.sql
+++ b/schemas/migrations/034_weekly_recap_week_start_check.sql
@@ -1,0 +1,10 @@
+-- CareerOtter Phase 2 — enforce the Monday week boundary on weekly_recaps.
+-- Separate migration (not an edit to 032): 032 uses CREATE TABLE IF NOT EXISTS,
+-- so amending it in place would silently skip the constraint on any database
+-- where 032 already ran. ALTER guarantees the CHECK is added everywhere 034 runs.
+-- Postgres extract(dow) is 0=Sunday..6=Saturday, so Monday = 1. The recap cron
+-- (weekStartOf) already computes Monday 00:00 UTC, so existing rows conform.
+
+alter table public.weekly_recaps
+  add constraint weekly_recaps_week_start_monday
+  check (extract(dow from week_start) = 1);


### PR DESCRIPTION
## M2a — Evidence loop: data + API foundation

The activation bet (PRD §M2), split into **M2a (data + API, this PR)** and **M2b (UI, next)**. Greenfield — verified no prior wins/goals/career-mode primitives existed.

### What's here
- **Migration `032_careerotter_evidence.sql`:** `career_profiles` (the goal frame + onboarding state + the onboarding fork `mode`), `wins` (the evidence log), `weekly_recaps`. RLS **service-role-only** (API-route access only per CLAUDE.md rule 4), `updated_at` trigger, indexes. `lib/constants/careerotter.ts` mirrors the CHECK lists and is **drift-guarded by a test**.
- **Voice guardrails (`lib/ai/voice-guardrails.ts`):** the brand guide's banned-construction list as ONE versioned prompt fragment, to be imported into every model-facing prompt. Zero to Case is the first consumer; the coach (M3), recap, and case builder (M4) reuse it.
- **Wins API:** `GET`/`POST /api/wins` + `PATCH`/`DELETE /api/wins/:id`. **Logging is free** (no model call — habit before payment). Identity from the session; writes via the service-role admin client, every query scoped to `user_id`. Server-authoritative `win_logged`.
- **Zero to Case:** `POST /api/careerotter/zero-to-case` — three answers → a model-drafted starter case (the one free onboarding AI call, like the roast), **idempotent** (returns the stored case without a second call), seeds the wins log, fires `ztc_completed`.
- **Analytics:** `careerotter` event names + client track helpers (`ztc_started`, `win_logged`, `recap_opened`).

### Gates
- `npx tsc --noEmit`: **374 = baseline, zero new.**
- `pnpm test`: **103 suites / 1486 pass** (+3: wins API, zero-to-case, constants drift).

### Deploy step (owner)
Apply the migration before the code deploys:
```
./scripts/run-schema.sh schemas/migrations/032_careerotter_evidence.sql
```
Not applied to prod from this PR (additive `CREATE TABLE IF NOT EXISTS`, but it's a hard-to-reverse action on an unmerged branch).

### Next: M2b
Today dashboard + capture bar + wins list + Zero-to-Case onboarding UI + coverage meter + review countdown + weekly recap (cron + email, needs the warmed careerotter.io domain from M1) + privacy posture/export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded CareerOtter onboarding with starter-case generation, optional goals/review dates, and persisted completion status.
  - Added authenticated wins listing, creation, editing, and deletion with server-controlled sources.
  - Added shared analytics events and improved AI-generated content consistency.
  - Added structured CareerOtter evidence storage and weekly recap date validation.

- **Bug Fixes**
  - Strengthened input validation, ownership checks, idempotency, and retry handling after failed generation.

- **Tests**
  - Added coverage for authentication, validation, idempotency, ownership, errors, analytics, and constant-to-database consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->