### PR TITLE
CareerOtter Phase 2 · M3 — Coach v1 (grounded chat + eval set)

### DIFF
--- a/__tests__/api/careerotter-coach.test.ts
+++ b/__tests__/api/careerotter-coach.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for POST /api/careerotter/coach (M3):
+ * - 401 unauth, 403 for Free (Pro-gated), 400 bad messages, 200 for Pro
+ * - the reply comes back and coach_message_sent fires
+ */
+
+import { POST } from "@/app/api/careerotter/coach/route";
+import { NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin-client";
+import { PermissionMiddleware } from "@/lib/middleware/permissions";
+import { callOpenAI } from "@/lib/openai/client";
+import { captureServerEvent } from "@/lib/analytics/posthog-server";
+import { CAREEROTTER_EVENT_NAMES } from "@/lib/analytics/careerotter-event-names";
+
+jest.mock("@/lib/supabase/server", () => ({ createClient: jest.fn() }));
+jest.mock("@/lib/supabase/admin-client", () => ({ createAdminClient: jest.fn() }));
+jest.mock("@/lib/openai/client", () => ({ callOpenAI: jest.fn() }));
+jest.mock("@/lib/analytics/posthog-server", () => ({
+  captureServerEvent: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock("@/lib/middleware/permissions", () => ({
+  PermissionMiddleware: { getUserPlanInfo: jest.fn() },
+}));
+jest.mock("@/lib/services/logger.service", () => ({
+  loggerService: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+const mockCreateClient = createClient as jest.Mock;
+const mockAdmin = createAdminClient as jest.Mock;
+const mockPlan = PermissionMiddleware.getUserPlanInfo as jest.Mock;
+const mockCall = callOpenAI as jest.Mock;
+const mockCapture = captureServerEvent as jest.Mock;
+
+const USER = { id: "user-1", email: "u@example.com" };
+
+function setUser(user: unknown) {
+  mockCreateClient.mockResolvedValue({
+    auth: { getUser: jest.fn().mockResolvedValue({ data: { user }, error: null }) },
+  });
+}
+
+function adminReturning(result: { data: unknown; error: unknown }) {
+  const b: Record<string, unknown> = {};
+  for (const m of ["from", "select", "eq", "order", "maybeSingle"]) b[m] = jest.fn(() => b);
+  (b as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  mockAdmin.mockReturnValue(b);
+}
+
+function req(body: unknown) {
+  return new NextRequest("http://localhost:3000/api/careerotter/coach", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const USER_MSG = { messages: [{ role: "user", content: "am i ready?" }] };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setUser(USER);
+  mockPlan.mockResolvedValue({ isPro: true });
+  adminReturning({ data: [], error: null });
+});
+
+it("401 when unauthenticated", async () => {
+  setUser(null);
+  expect((await POST(req(USER_MSG))).status).toBe(401);
+});
+
+it("403 for a Free user (Pro-gated)", async () => {
+  mockPlan.mockResolvedValue({ isPro: false });
+  const res = await POST(req(USER_MSG));
+  expect(res.status).toBe(403);
+  expect(mockCall).not.toHaveBeenCalled();
+});
+
+it("400 when messages are empty or malformed", async () => {
+  expect((await POST(req({ messages: [] }))).status).toBe(400);
+  expect((await POST(req({ messages: [{ role: "assistant", content: "hi" }] }))).status).toBe(400);
+});
+
+it("returns the reply and fires coach_message_sent for a Pro user", async () => {
+  mockCall.mockResolvedValue("Take the Q3 postmortem and log it.");
+  const res = await POST(req(USER_MSG));
+  expect(res.status).toBe(200);
+  expect((await res.json()).reply).toBe("Take the Q3 postmortem and log it.");
+  expect(mockCapture).toHaveBeenCalledWith(
+    USER.id,
+    CAREEROTTER_EVENT_NAMES.COACH_MESSAGE_SENT,
+    expect.objectContaining({ turns: 1 })
+  );
+});
+
+it("502 when the model call fails", async () => {
+  mockCall.mockRejectedValue(new Error("model down"));
+  expect((await POST(req(USER_MSG))).status).toBe(502);
+});

--- a/__tests__/lib/careerotter-coach.test.ts
+++ b/__tests__/lib/careerotter-coach.test.ts
@@ -1,0 +1,75 @@
+// @jest-environment node
+import { findBannedConstructions, isVoiceClean } from "@/lib/ai/voice-check";
+import {
+  buildCoachSystemPrompt,
+  COACH_STARTERS,
+} from "@/lib/careerotter/coach-prompt";
+import {
+  COACH_EVAL_PROFILES,
+  evaluateCoachOutput,
+} from "@/lib/careerotter/coach-eval";
+
+describe("voice checker", () => {
+  it("flags an em dash", () => {
+    expect(findBannedConstructions("You are strong — but shallow.").length).toBeGreaterThan(0);
+  });
+  it("flags the contrast scaffold", () => {
+    expect(isVoiceClean("It's not about the wins, it's about the story.")).toBe(false);
+  });
+  it("flags banned filler", () => {
+    expect(isVoiceClean("Let's unpack your leadership story.")).toBe(false);
+  });
+  it("passes clean, direct copy", () => {
+    expect(isVoiceClean("Two delivery wins this quarter. Log a leadership one by Friday.")).toBe(true);
+  });
+});
+
+describe("buildCoachSystemPrompt", () => {
+  const wins = [{ text: "Shipped billing migration early", tag: "delivery" }];
+
+  it("embeds the grounding rule and lists the wins", () => {
+    const p = buildCoachSystemPrompt({ mode: "promotion" }, wins);
+    expect(p).toMatch(/only reason from the evidence/i);
+    expect(p).toContain("Shipped billing migration early");
+  });
+
+  it("states when the user has no wins", () => {
+    const p = buildCoachSystemPrompt({ mode: "raise" }, []);
+    expect(p).toMatch(/no wins yet/i);
+  });
+
+  it("has exactly three seeded starters", () => {
+    expect(COACH_STARTERS).toHaveLength(3);
+  });
+});
+
+describe("coach eval set", () => {
+  it("has ten graded profiles with unique ids", () => {
+    expect(COACH_EVAL_PROFILES).toHaveLength(10);
+    const ids = new Set(COACH_EVAL_PROFILES.map((p) => p.id));
+    expect(ids.size).toBe(10);
+  });
+
+  it("grader passes a grounded, actionable, clean reply", () => {
+    const profile = COACH_EVAL_PROFILES[0]; // strong-delivery-no-leadership
+    const good =
+      "Your billing migration is strong delivery evidence. The gap is leadership. Take the Q3 postmortem, run it, and log it before your review.";
+    expect(evaluateCoachOutput(profile, good).passed).toBe(true);
+  });
+
+  it("grader fails a reply with a banned construction", () => {
+    const profile = COACH_EVAL_PROFILES[0];
+    const bad =
+      "Let's dive in. Your billing migration is great, take the postmortem next.";
+    const res = evaluateCoachOutput(profile, bad);
+    expect(res.passed).toBe(false);
+    expect(res.issues.join()).toMatch(/voice/);
+  });
+
+  it("grader flags an empty-log reply that invents instead of asking", () => {
+    const empty = COACH_EVAL_PROFILES.find((p) => p.id === "empty-log")!;
+    const invented = "You are clearly ready. Go ask for 15%.";
+    const res = evaluateCoachOutput(empty, invented);
+    expect(res.passed).toBe(false);
+  });
+});

--- a/app/(app)/dashboard/coach/page.tsx
+++ b/app/(app)/dashboard/coach/page.tsx
@@ -1,0 +1,31 @@
+export const dynamic = "force-dynamic";
+
+import { redirect } from "next/navigation";
+import { NavigationServer } from "@/components/navigation-server";
+import { getUser } from "@/lib/supabase/server";
+import { CoachChat } from "@/components/careerotter/coach-chat";
+
+/**
+ * The coach (CareerOtter M3). Pro-gated at the API; the page renders for any
+ * signed-in user and the API returns a clear 403 for Free, which the chat
+ * surfaces inline.
+ */
+export default async function CoachPage() {
+  const user = await getUser();
+  if (!user) redirect("/login");
+
+  return (
+    <div className="min-h-screen bg-background">
+      <NavigationServer />
+      <main className="container mx-auto max-w-3xl px-4 py-8">
+        <div className="mb-6 space-y-1">
+          <h1 className="text-2xl font-bold">Coach</h1>
+          <p className="text-sm text-muted-foreground">
+            Grounded in your logged wins, your goal, and your review date.
+          </p>
+        </div>
+        <CoachChat />
+      </main>
+    </div>
+  );
+}

--- a/app/api/careerotter/coach/route.ts
+++ b/app/api/careerotter/coach/route.ts
@@ -1,0 +1,123 @@
+/**
+ * Coach v1 (CareerOtter Phase 2, M3).
+ *
+ * POST /api/careerotter/coach   { messages: {role, content}[] }
+ *
+ * Pro-only (it calls the model). Grounded exclusively in the user's logged wins,
+ * goal, and review date via buildCoachSystemPrompt. Returns the assistant reply.
+ */
+
+import { type NextRequest, NextResponse, after } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin-client";
+import { PermissionMiddleware } from "@/lib/middleware/permissions";
+import { callOpenAI } from "@/lib/openai/client";
+import { buildCoachSystemPrompt, COACH_PROMPT_VERSION } from "@/lib/careerotter/coach-prompt";
+import { CAREEROTTER_EVENT_NAMES } from "@/lib/analytics/careerotter-event-names";
+import { captureServerEvent } from "@/lib/analytics/posthog-server";
+import { loggerService } from "@/lib/services/logger.service";
+import { LogCategory } from "@/lib/services/logger.types";
+
+export const maxDuration = 60;
+
+const MAX_MESSAGES = 30;
+const MAX_CONTENT = 4000;
+
+type Msg = { role: "user" | "assistant"; content: string };
+
+function parseMessages(raw: unknown): Msg[] | null {
+  if (!Array.isArray(raw) || raw.length === 0 || raw.length > MAX_MESSAGES) {
+    return null;
+  }
+  const out: Msg[] = [];
+  for (const m of raw) {
+    const role = (m as { role?: unknown })?.role;
+    const content = (m as { content?: unknown })?.content;
+    if ((role !== "user" && role !== "assistant") || typeof content !== "string") {
+      return null;
+    }
+    const trimmed = content.trim();
+    if (!trimmed) return null;
+    out.push({ role, content: trimmed.slice(0, MAX_CONTENT) });
+  }
+  // The last turn must be from the user.
+  if (out[out.length - 1].role !== "user") return null;
+  return out;
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Pro-gated: the coach is the paid AI layer.
+  const plan = await PermissionMiddleware.getUserPlanInfo(user.id);
+  if (!plan.isPro) {
+    return NextResponse.json(
+      { error: "The coach is a Pro feature.", requiredPlan: "Pro" },
+      { status: 403 }
+    );
+  }
+
+  let body: { messages?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  const messages = parseMessages(body.messages);
+  if (!messages) {
+    return NextResponse.json(
+      { error: "messages must be a non-empty list ending with a user turn" },
+      { status: 400 }
+    );
+  }
+
+  const admin = createAdminClient();
+  const [{ data: wins }, { data: profile }] = await Promise.all([
+    admin
+      .from("wins")
+      .select("text, impact_number, tag, created_at")
+      .eq("user_id", user.id)
+      .order("created_at", { ascending: false }),
+    admin
+      .from("career_profiles")
+      .select("mode, role, level, target, review_date")
+      .eq("user_id", user.id)
+      .maybeSingle(),
+  ]);
+
+  let reply = "";
+  try {
+    reply = await callOpenAI({
+      systemPrompt: buildCoachSystemPrompt(profile ?? null, wins ?? []),
+      messages,
+      maxTokens: 900,
+      temperature: 0.5,
+    });
+  } catch (error) {
+    loggerService.error("Coach generation failed", error, {
+      category: LogCategory.AI_SERVICE,
+      userId: user.id,
+      action: "coach_generation_failed",
+    });
+    return NextResponse.json(
+      { error: "The coach is unavailable right now. Please try again." },
+      { status: 502 }
+    );
+  }
+
+  after(
+    captureServerEvent(user.id, CAREEROTTER_EVENT_NAMES.COACH_MESSAGE_SENT, {
+      prompt_version: COACH_PROMPT_VERSION,
+      turns: messages.length,
+      has_wins: (wins?.length ?? 0) > 0,
+    })
+  );
+
+  return NextResponse.json({ reply });
+}

--- a/components/careerotter/coach-chat.tsx
+++ b/components/careerotter/coach-chat.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent } from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
+import { COACH_STARTERS } from "@/lib/careerotter/coach-prompt";
+
+type Msg = { role: "user" | "assistant"; content: string };
+
+/**
+ * Coach chat (M3). Grounded server-side in the user's wins; this is just the
+ * transcript + input. Seeded starters get a cold-start user moving.
+ */
+export function CoachChat() {
+  const [messages, setMessages] = useState<Msg[]>([]);
+  const [input, setInput] = useState("");
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState("");
+
+  async function send(text: string) {
+    const trimmed = text.trim();
+    if (!trimmed || sending) return;
+    setError("");
+    const next: Msg[] = [...messages, { role: "user", content: trimmed }];
+    setMessages(next);
+    setInput("");
+    setSending(true);
+    try {
+      const res = await fetch("/api/careerotter/coach", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ messages: next }),
+      });
+      const data = await res.json().catch(() => null);
+      if (res.ok && data?.reply) {
+        setMessages((prev) => [...prev, { role: "assistant", content: data.reply }]);
+      } else {
+        setError(data?.error || "The coach is unavailable right now.");
+      }
+    } catch {
+      setError("The coach is unavailable right now.");
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {messages.length === 0 && (
+        <div className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            The coach reasons from what you have logged. Start here:
+          </p>
+          <div className="flex flex-col gap-2">
+            {COACH_STARTERS.map((s) => (
+              <Button
+                key={s}
+                variant="outline"
+                className="justify-start text-left"
+                onClick={() => send(s)}
+                disabled={sending}
+              >
+                {s}
+              </Button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <ul className="space-y-3">
+        {messages.map((m, i) => (
+          <li key={i} className={m.role === "user" ? "text-right" : ""}>
+            <Card
+              className={
+                m.role === "user" ? "inline-block bg-muted" : "inline-block"
+              }
+            >
+              <CardContent className="p-3 text-sm leading-relaxed whitespace-pre-wrap">
+                {m.content}
+              </CardContent>
+            </Card>
+          </li>
+        ))}
+        {sending && (
+          <li>
+            <Spinner size="sm" />
+          </li>
+        )}
+      </ul>
+
+      {error && (
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      )}
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          send(input);
+        }}
+        className="flex gap-2"
+      >
+        <Input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Ask the coach about your case…"
+          disabled={sending}
+          className="min-h-[44px] flex-1"
+          aria-label="Message the coach"
+        />
+        <Button type="submit" disabled={sending || !input.trim()} className="min-h-[44px]">
+          Send
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/lib/ai/voice-check.ts
+++ b/lib/ai/voice-check.ts
@@ -1,0 +1,71 @@
+/**
+ * Voice checker — detects the banned constructions from the brand guide §3.2 in
+ * generated text. Used by the coach eval set (M3) and available for any model
+ * output review. Heuristic, not exhaustive: catches the loud, common tells.
+ */
+
+const BANNED_PHRASES = [
+  "let's dive in",
+  "let's unpack",
+  "deep dive",
+  "unlock",
+  "supercharge",
+  "elevate",
+  "empower",
+  "leverage",
+  "streamline",
+  "seamless",
+  "robust",
+  "holistic",
+  "navigate",
+  "delve",
+  "realm",
+  "tapestry",
+  "landscape",
+  "in today's world",
+  "it's worth noting",
+  "it's important to remember",
+  "keep in mind that",
+  "at the end of the day",
+  "great question",
+  "you're absolutely right",
+  "spot on",
+  "as an ai",
+  "i'm just an ai",
+];
+
+// "not X, it's Y" / "not just X, but Y" / "isn't about X, it's about Y".
+const CONTRAST_SCAFFOLD =
+  /\b(it'?s not|not just|isn'?t about|it isn'?t)\b[^.?!]{1,60}?,?\s+(it'?s|but|it'?s about)\b/i;
+
+export interface VoiceViolation {
+  rule: string;
+  match: string;
+}
+
+export function findBannedConstructions(text: string): VoiceViolation[] {
+  const violations: VoiceViolation[] = [];
+  const lower = text.toLowerCase();
+
+  // Em dash (— or the double-hyphen stand-in).
+  if (/—/.test(text) || /\s--\s/.test(text)) {
+    violations.push({ rule: "em-dash", match: "—" });
+  }
+
+  for (const phrase of BANNED_PHRASES) {
+    if (lower.includes(phrase)) {
+      violations.push({ rule: "banned-phrase", match: phrase });
+    }
+  }
+
+  const scaffold = text.match(CONTRAST_SCAFFOLD);
+  if (scaffold) {
+    violations.push({ rule: "contrast-scaffold", match: scaffold[0] });
+  }
+
+  return violations;
+}
+
+export function isVoiceClean(text: string): boolean {
+  return findBannedConstructions(text).length === 0;
+}

--- a/lib/careerotter/coach-eval.ts
+++ b/lib/careerotter/coach-eval.ts
@@ -1,0 +1,188 @@
+/**
+ * Coach eval set (M3, required before ship). Ten synthetic user profiles across
+ * a range of win density and gap patterns, each with a question and graded
+ * expectations. The runner (evaluateCoachOutput) grades a generated reply
+ * against a profile; re-run on every prompt change.
+ *
+ * Live grading calls the model, so it is not a unit test (cost + nondeterminism).
+ * Unit tests assert the SET's shape and the GRADER's logic. Run the live eval
+ * with a script that feeds each profile through buildCoachSystemPrompt + the
+ * model and reports pass rate.
+ */
+
+import type { CoachProfile, CoachWin } from "./coach-prompt";
+import { findBannedConstructions } from "@/lib/ai/voice-check";
+
+export interface CoachEvalProfile {
+  id: string;
+  profile: CoachProfile;
+  wins: CoachWin[];
+  question: string;
+  expect: {
+    /** Reply should cite the user's actual win content (when they have wins). */
+    referencesWin: boolean;
+    /** Reply should end with / contain a concrete next step. */
+    includesNextAction: boolean;
+    /** When wins are empty, reply should say what to log rather than invent. */
+    asksForMissingData?: boolean;
+  };
+}
+
+const win = (text: string, tag: CoachWin["tag"], impact?: string): CoachWin => ({
+  text,
+  tag,
+  impact_number: impact ?? null,
+});
+
+export const COACH_EVAL_PROFILES: CoachEvalProfile[] = [
+  {
+    id: "strong-delivery-no-leadership",
+    profile: { mode: "promotion", role: "Senior Engineer", review_date: "2026-09-14" },
+    wins: [
+      win("Shipped billing migration two weeks early", "delivery", "2 weeks early"),
+      win("Cut review-queue p95 from 4d to 26h", "delivery", "4d to 26h"),
+      win("Fixed the flaky deploy pipeline", "delivery"),
+    ],
+    question: "What's the weakest part of my case?",
+    expect: { referencesWin: true, includesNextAction: true },
+  },
+  {
+    id: "empty-log",
+    profile: { mode: "raise", role: "PM" },
+    wins: [],
+    question: "Am I ready to ask for a raise?",
+    expect: { referencesWin: false, includesNextAction: true, asksForMissingData: true },
+  },
+  {
+    id: "balanced-case",
+    profile: { mode: "promotion", role: "Staff Engineer", review_date: "2026-08-01" },
+    wins: [
+      win("Led the postmortem for the Q2 outage", "leadership"),
+      win("Mentored two juniors to first ships", "leadership"),
+      win("Unblocked the data team's schema review", "collaboration"),
+      win("Shipped the search rewrite", "delivery", "30% faster"),
+      win("Set the code-review standard doc", "craft"),
+    ],
+    question: "Draft my 1:1 talking points for this week",
+    expect: { referencesWin: true, includesNextAction: true },
+  },
+  {
+    id: "one-win-only",
+    profile: { mode: "promotion", role: "Designer" },
+    wins: [win("Redesigned onboarding, activation up 12%", "delivery", "+12%")],
+    question: "How strong is my case?",
+    expect: { referencesWin: true, includesNextAction: true },
+  },
+  {
+    id: "collaboration-heavy",
+    profile: { mode: "raise", role: "EM", review_date: "2026-10-01" },
+    wins: [
+      win("Brokered the platform/product roadmap conflict", "collaboration"),
+      win("Ran cross-team incident review", "collaboration"),
+      win("Aligned three teams on the API contract", "collaboration"),
+    ],
+    question: "What gap should I close before my review?",
+    expect: { referencesWin: true, includesNextAction: true },
+  },
+  {
+    id: "craft-heavy",
+    profile: { mode: "promotion", role: "Senior Engineer" },
+    wins: [
+      win("Wrote the testing guide the team adopted", "craft"),
+      win("Refactored the auth module, halved its size", "craft", "-50% LOC"),
+    ],
+    question: "Am I ready to ask?",
+    expect: { referencesWin: true, includesNextAction: true },
+  },
+  {
+    id: "job-search-mode",
+    profile: { mode: "job_search", role: "Backend Engineer" },
+    wins: [win("Owned the payments service end to end", "delivery")],
+    question: "How do I talk about my impact in interviews?",
+    expect: { referencesWin: true, includesNextAction: true },
+  },
+  {
+    id: "review-imminent",
+    profile: { mode: "promotion", role: "Senior PM", review_date: "2026-07-25" },
+    wins: [
+      win("Launched the pricing experiment, +8% conversion", "delivery", "+8%"),
+      win("Recovered the stalled partner integration", "collaboration"),
+    ],
+    question: "My review is in a week. What do I lead with?",
+    expect: { referencesWin: true, includesNextAction: true },
+  },
+  {
+    id: "high-volume-one-area",
+    profile: { mode: "promotion", role: "Data Engineer" },
+    wins: Array.from({ length: 8 }, (_, i) => win(`Shipped pipeline task ${i + 1}`, "delivery")),
+    question: "What's missing from my case?",
+    expect: { referencesWin: true, includesNextAction: true },
+  },
+  {
+    id: "no-review-date",
+    profile: { mode: "raise", role: "Engineer" },
+    wins: [
+      win("Reduced infra cost 20%", "delivery", "-20%"),
+      win("Onboarded the new hire", "leadership"),
+    ],
+    question: "Should I ask now or wait?",
+    expect: { referencesWin: true, includesNextAction: true },
+  },
+];
+
+// Verbs that signal a concrete next step.
+const NEXT_ACTION_HINTS = [
+  "log", "add", "ask", "take", "run", "draft", "write", "own", "lead",
+  "close", "bring", "do ", "put ", "record", "before your review", "this week",
+  "next", "start",
+];
+
+export interface CoachEvalResult {
+  id: string;
+  passed: boolean;
+  issues: string[];
+}
+
+/**
+ * Grade a generated reply against a profile's expectations. Deterministic
+ * heuristics only (voice cleanliness, next-action presence, win grounding).
+ */
+export function evaluateCoachOutput(
+  profileCase: CoachEvalProfile,
+  reply: string
+): CoachEvalResult {
+  const issues: string[] = [];
+  const lower = reply.toLowerCase();
+
+  const voice = findBannedConstructions(reply);
+  if (voice.length > 0) {
+    issues.push(`voice: ${voice.map((v) => v.rule).join(", ")}`);
+  }
+
+  if (profileCase.expect.includesNextAction) {
+    if (!NEXT_ACTION_HINTS.some((h) => lower.includes(h))) {
+      issues.push("no next action");
+    }
+  }
+
+  if (profileCase.expect.referencesWin && profileCase.wins.length > 0) {
+    // A loose grounding check: the reply should echo a distinctive word from
+    // at least one logged win.
+    const grounded = profileCase.wins.some((w) => {
+      const keyword = w.text
+        .toLowerCase()
+        .split(/\W+/)
+        .find((word) => word.length >= 5);
+      return keyword ? lower.includes(keyword) : false;
+    });
+    if (!grounded) issues.push("does not reference a logged win");
+  }
+
+  if (profileCase.expect.asksForMissingData) {
+    if (!/(log|add|capture|start logging|haven'?t logged|no wins)/i.test(reply)) {
+      issues.push("empty log: did not ask for missing data");
+    }
+  }
+
+  return { id: profileCase.id, passed: issues.length === 0, issues };
+}

--- a/lib/careerotter/coach-prompt.ts
+++ b/lib/careerotter/coach-prompt.ts
@@ -1,0 +1,97 @@
+/**
+ * Coach v1 prompt construction (M3). The coach is grounded EXCLUSIVELY in the
+ * user's logged wins, goal, and review date. If an answer isn't derivable from
+ * their data plus general negotiation/promo knowledge, it says what's missing
+ * and how to log it — never generic career advice (that's the "wrapper" failure
+ * the RFC warns about). Voice guardrails are embedded verbatim.
+ */
+
+import { VOICE_GUARDRAILS } from "@/lib/ai/voice-guardrails";
+import { WIN_TAGS, WIN_TAG_OPTIONS, type WinTag } from "@/lib/constants/careerotter";
+
+export const COACH_PROMPT_VERSION = "1.0.0";
+
+// Three seeded conversation starters (RFC / PRD M3).
+export const COACH_STARTERS = [
+  "What's the weakest part of my case?",
+  "Draft my 1:1 talking points for this week",
+  "Am I ready to ask?",
+] as const;
+
+export interface CoachProfile {
+  mode?: string | null;
+  role?: string | null;
+  level?: string | null;
+  target?: string | null;
+  review_date?: string | null;
+}
+
+export interface CoachWin {
+  text: string;
+  impact_number?: string | null;
+  tag?: string | null;
+  created_at?: string;
+}
+
+const TAG_LABEL: Record<WinTag, string> = Object.fromEntries(
+  WIN_TAG_OPTIONS.map((o) => [o.value, o.label])
+) as Record<WinTag, string>;
+
+/**
+ * Build the coach system prompt from the user's data. Wins are listed as the
+ * evidence the coach may reference; the grounding rule is explicit.
+ */
+export function buildCoachSystemPrompt(
+  profile: CoachProfile | null,
+  wins: CoachWin[]
+): string {
+  const goal =
+    profile?.mode === "job_search"
+      ? "landing a better role"
+      : profile?.mode === "raise"
+        ? "a raise"
+        : "a promotion";
+
+  const context: string[] = [`Their goal: ${goal}.`];
+  if (profile?.role) context.push(`Role: ${profile.role}${profile.level ? `, ${profile.level}` : ""}.`);
+  if (profile?.target) context.push(`Target: ${profile.target}.`);
+  if (profile?.review_date) context.push(`Next review: ${profile.review_date}.`);
+
+  // Emptiest impact area (fewest wins, first tag on a tie) — the gap the coach
+  // should point at. Computed inline to keep this prompt module dependency-light.
+  const tagCounts = new Map<WinTag, number>(WIN_TAGS.map((t) => [t, 0]));
+  for (const w of wins) {
+    if (w.tag && tagCounts.has(w.tag as WinTag)) {
+      tagCounts.set(w.tag as WinTag, (tagCounts.get(w.tag as WinTag) ?? 0) + 1);
+    }
+  }
+  const emptiest = WIN_TAGS.reduce((min, t) =>
+    (tagCounts.get(t) ?? 0) < (tagCounts.get(min) ?? 0) ? t : min
+  );
+  if (wins.length > 0 && (tagCounts.get(emptiest) ?? 0) === 0) {
+    context.push(`Emptiest area (no evidence yet): ${TAG_LABEL[emptiest]}.`);
+  }
+
+  const winLines =
+    wins.length === 0
+      ? "The user has logged no wins yet."
+      : wins
+          .map((w, i) => {
+            const tag = w.tag ? ` [${TAG_LABEL[w.tag as WinTag] ?? w.tag}]` : "";
+            const impact = w.impact_number ? ` (${w.impact_number})` : "";
+            return `${i + 1}. ${w.text}${impact}${tag}`;
+          })
+          .join("\n");
+
+  return `${VOICE_GUARDRAILS}
+
+You are coaching this user toward their goal. You may only reason from the evidence below plus general, well-established negotiation and promotion knowledge. Do not invent wins, numbers, or facts about them. If a good answer needs information they haven't logged, say exactly what's missing and how to log it (one line in the capture bar), then answer with what you do have.
+
+Every hard truth ships with the next action. Reference their actual wins by their content when you use them.
+
+Their context:
+${context.join("\n")}
+
+Their logged wins (the only evidence you may cite):
+${winLines}`;
+}


### PR DESCRIPTION
## M3 — Coach v1

The paid AI layer, grounded in the user's own evidence (the RFC's "price justification"). **Base is `careerotter/m2a-evidence-data`** (needs the wins table + constants) — merge #184 first.

### What's here
- **Coach API** (`POST /api/careerotter/coach`) — **Pro-gated** (`isPro`). Loads the user's wins + goal + review date and builds a system prompt that may **only** reason from that evidence plus general negotiation/promo knowledge. If an answer needs data they haven't logged, it says what's missing and how to log it — never generic wrapper advice (the RFC's stated failure mode). Voice guardrails embedded verbatim. Fires `coach_message_sent`.
- **Grounded prompt** (`lib/careerotter/coach-prompt.ts`) — versioned; lists the wins as the only citable evidence, names the emptiest impact area; 3 seeded starters.
- **Eval set** (`lib/careerotter/coach-eval.ts`) — **10 synthetic profiles** across win density + gap patterns with graded expectations, plus `evaluateCoachOutput()` (deterministic checks: voice cleanliness, next-action present, win grounding, empty-log handling). PRD requires this before ship. Re-run on every prompt change; the live run (model calls) is a script.
- **Voice checker** (`lib/ai/voice-check.ts`) — detects the banned constructions (em dash, contrast scaffold, filler/hedge/flattery).
- **Coach chat UI** (`/dashboard/coach`) with seeded starters; Free users get the API's 403 surfaced inline.

### Gates
- `pnpm test`: **105 suites / 1502 pass** (+2: coach lib, coach route).
- `npx tsc --noEmit`: **375 vs 374 baseline** — the +1 is the coach page's async-`NavigationServer` `TS2786` (the pattern every dashboard page emits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)