### PR TITLE
CareerOtter Phase 2 · M4 — Promo case builder + export

### DIFF
--- a/__tests__/api/careerotter-case.test.ts
+++ b/__tests__/api/careerotter-case.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for the promo case builder (M4):
+ * - buildCasePrompt is grounded + first-person, uses the rubric
+ * - POST route: 401 unauth, 403 Free, 422 too-few-wins, 200 Pro + case_exported
+ */
+
+import { POST } from "@/app/api/careerotter/case/route";
+import { buildCasePrompt, CASE_RUBRIC_V1 } from "@/lib/careerotter/case-prompt";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin-client";
+import { PermissionMiddleware } from "@/lib/middleware/permissions";
+import { callOpenAI } from "@/lib/openai/client";
+import { captureServerEvent } from "@/lib/analytics/posthog-server";
+import { CAREEROTTER_EVENT_NAMES } from "@/lib/analytics/careerotter-event-names";
+
+jest.mock("@/lib/supabase/server", () => ({ createClient: jest.fn() }));
+jest.mock("@/lib/supabase/admin-client", () => ({ createAdminClient: jest.fn() }));
+jest.mock("@/lib/openai/client", () => ({ callOpenAI: jest.fn() }));
+jest.mock("@/lib/analytics/posthog-server", () => ({
+  captureServerEvent: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock("@/lib/middleware/permissions", () => ({
+  PermissionMiddleware: { getUserPlanInfo: jest.fn() },
+}));
+jest.mock("@/lib/services/logger.service", () => ({
+  loggerService: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+const mockCreateClient = createClient as jest.Mock;
+const mockAdmin = createAdminClient as jest.Mock;
+const mockPlan = PermissionMiddleware.getUserPlanInfo as jest.Mock;
+const mockCall = callOpenAI as jest.Mock;
+const mockCapture = captureServerEvent as jest.Mock;
+
+const USER = { id: "user-1", email: "u@example.com" };
+
+function setUser(user: unknown) {
+  mockCreateClient.mockResolvedValue({
+    auth: { getUser: jest.fn().mockResolvedValue({ data: { user }, error: null }) },
+  });
+}
+
+// The route runs two awaited queries in Promise.all: wins then profile. Return
+// wins for the first call and profile for the second.
+function adminWith(wins: unknown, profile: unknown) {
+  let call = 0;
+  mockAdmin.mockReturnValue(
+    new Proxy(
+      {},
+      {
+        get(_t, prop) {
+          if (prop === "then") {
+            return (resolve: (v: unknown) => void) => {
+              const result = call === 0 ? { data: wins, error: null } : { data: profile, error: null };
+              call += 1;
+              resolve(result);
+            };
+          }
+          return () => mockAdmin();
+        },
+      }
+    )
+  );
+}
+
+describe("buildCasePrompt", () => {
+  it("is grounded, first-person, and uses the rubric sections", () => {
+    const p = buildCasePrompt({ mode: "promotion" }, [
+      { text: "Shipped billing migration", tag: "delivery" },
+    ]);
+    expect(p).toMatch(/first-person/i);
+    expect(p).toContain("Shipped billing migration");
+    expect(p).toContain(CASE_RUBRIC_V1[0].split(":")[0]); // "Summary"
+    expect(p).toMatch(/only the wins below|only evidence|do not invent/i);
+  });
+});
+
+describe("POST /api/careerotter/case", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setUser(USER);
+    mockPlan.mockResolvedValue({ isPro: true });
+  });
+
+  it("401 when unauthenticated", async () => {
+    setUser(null);
+    expect((await POST()).status).toBe(401);
+  });
+
+  it("403 for a Free user", async () => {
+    mockPlan.mockResolvedValue({ isPro: false });
+    expect((await POST()).status).toBe(403);
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+
+  it("422 when there are too few wins", async () => {
+    adminWith([{ text: "one" }], null);
+    const res = await POST();
+    expect(res.status).toBe(422);
+    expect((await res.json()).needsMoreWins).toBe(true);
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+
+  it("200 with markdown and fires case_exported when there is enough evidence", async () => {
+    adminWith(
+      [{ text: "a" }, { text: "b" }, { text: "c" }],
+      { mode: "promotion" }
+    );
+    mockCall.mockResolvedValue("# My Case\n...");
+    const res = await POST();
+    expect(res.status).toBe(200);
+    expect((await res.json()).markdown).toContain("My Case");
+    expect(mockCapture).toHaveBeenCalledWith(
+      USER.id,
+      CAREEROTTER_EVENT_NAMES.CASE_EXPORTED,
+      expect.objectContaining({ wins_used: 3 })
+    );
+  });
+});

--- a/app/(app)/dashboard/review-prep/page.tsx
+++ b/app/(app)/dashboard/review-prep/page.tsx
@@ -1,0 +1,30 @@
+export const dynamic = "force-dynamic";
+
+import { redirect } from "next/navigation";
+import { NavigationServer } from "@/components/navigation-server";
+import { getUser } from "@/lib/supabase/server";
+import { CaseBuilder } from "@/components/careerotter/case-builder";
+
+/**
+ * Review prep / promo case builder (CareerOtter M4). Pro-gated at the API; the
+ * page renders for any signed-in user and the API returns a clear 403 for Free.
+ */
+export default async function ReviewPrepPage() {
+  const user = await getUser();
+  if (!user) redirect("/login");
+
+  return (
+    <div className="min-h-screen bg-background">
+      <NavigationServer />
+      <main className="container mx-auto max-w-3xl px-4 py-8">
+        <div className="mb-6 space-y-1">
+          <h1 className="text-2xl font-bold">Review prep</h1>
+          <p className="text-sm text-muted-foreground">
+            Assemble your logged wins into a case you can walk in with.
+          </p>
+        </div>
+        <CaseBuilder />
+      </main>
+    </div>
+  );
+}

--- a/app/api/careerotter/case/route.ts
+++ b/app/api/careerotter/case/route.ts
@@ -1,0 +1,96 @@
+/**
+ * Promo case builder (CareerOtter Phase 2, M4).
+ *
+ * POST /api/careerotter/case  -> generates a structured case document (markdown)
+ *
+ * Pro-only. Grounded in the user's logged wins + goal via buildCasePrompt. Needs
+ * at least a few wins to be worth generating. Fires case_exported.
+ */
+
+import { NextResponse, after } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin-client";
+import { PermissionMiddleware } from "@/lib/middleware/permissions";
+import { callOpenAI } from "@/lib/openai/client";
+import { buildCasePrompt, CASE_PROMPT_VERSION } from "@/lib/careerotter/case-prompt";
+import { CAREEROTTER_EVENT_NAMES } from "@/lib/analytics/careerotter-event-names";
+import { captureServerEvent } from "@/lib/analytics/posthog-server";
+import { loggerService } from "@/lib/services/logger.service";
+import { LogCategory } from "@/lib/services/logger.types";
+
+export const maxDuration = 60;
+
+const MIN_WINS = 3;
+
+export async function POST() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const plan = await PermissionMiddleware.getUserPlanInfo(user.id);
+  if (!plan.isPro) {
+    return NextResponse.json(
+      { error: "The case builder is a Pro feature.", requiredPlan: "Pro" },
+      { status: 403 }
+    );
+  }
+
+  const admin = createAdminClient();
+  const [{ data: wins }, { data: profile }] = await Promise.all([
+    admin
+      .from("wins")
+      .select("text, impact_number, tag, created_at")
+      .eq("user_id", user.id)
+      .order("created_at", { ascending: false }),
+    admin
+      .from("career_profiles")
+      .select("mode, role, level, target, review_date")
+      .eq("user_id", user.id)
+      .maybeSingle(),
+  ]);
+
+  if (!wins || wins.length < MIN_WINS) {
+    return NextResponse.json(
+      {
+        error: `Log at least ${MIN_WINS} wins first — a case needs evidence to stand on.`,
+        needsMoreWins: true,
+      },
+      { status: 422 }
+    );
+  }
+
+  let markdown = "";
+  try {
+    markdown = await callOpenAI({
+      systemPrompt: buildCasePrompt(profile ?? null, wins),
+      messages: [
+        { role: "user", content: "Assemble my case document from my logged wins." },
+      ],
+      maxTokens: 1600,
+      temperature: 0.5,
+    });
+  } catch (error) {
+    loggerService.error("Case generation failed", error, {
+      category: LogCategory.AI_SERVICE,
+      userId: user.id,
+      action: "case_generation_failed",
+    });
+    return NextResponse.json(
+      { error: "Could not build your case right now. Please try again." },
+      { status: 502 }
+    );
+  }
+
+  after(
+    captureServerEvent(user.id, CAREEROTTER_EVENT_NAMES.CASE_EXPORTED, {
+      prompt_version: CASE_PROMPT_VERSION,
+      wins_used: wins.length,
+    })
+  );
+
+  return NextResponse.json({ markdown });
+}

--- a/components/careerotter/case-builder.tsx
+++ b/components/careerotter/case-builder.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
+import { Copy, Download, Printer } from "lucide-react";
+
+/**
+ * Case builder (M4). Generates a review-ready case from the user's logged wins
+ * and offers the three exports the PRD asks for: copy-to-clipboard, download
+ * (markdown), and print (browser "Save as PDF"). The document is the user's, so
+ * it renders plainly with no otter chrome.
+ */
+export function CaseBuilder() {
+  const [markdown, setMarkdown] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  async function generate() {
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch("/api/careerotter/case", { method: "POST" });
+      const data = await res.json().catch(() => null);
+      if (res.ok && data?.markdown) {
+        setMarkdown(data.markdown);
+      } else {
+        setError(data?.error || "Could not build your case right now.");
+      }
+    } catch {
+      setError("Could not build your case right now.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function copy() {
+    await navigator.clipboard.writeText(markdown);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  function download() {
+    const blob = new Blob([markdown], { type: "text/markdown" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "my-case.md";
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <Button onClick={generate} disabled={loading}>
+          {loading ? <Spinner size="sm" className="mr-2" /> : null}
+          {markdown ? "Rebuild case" : "Build my case"}
+        </Button>
+        {markdown && (
+          <>
+            <Button variant="outline" onClick={copy}>
+              <Copy className="mr-2 h-4 w-4" />
+              {copied ? "Copied" : "Copy"}
+            </Button>
+            <Button variant="outline" onClick={download}>
+              <Download className="mr-2 h-4 w-4" />
+              Download
+            </Button>
+            <Button variant="outline" onClick={() => window.print()}>
+              <Printer className="mr-2 h-4 w-4" />
+              Print / PDF
+            </Button>
+          </>
+        )}
+      </div>
+
+      {error && (
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      )}
+
+      {markdown && (
+        <Card className="print:border-0 print:shadow-none">
+          <CardContent className="p-6">
+            {/* The document is the user's; render it plainly. */}
+            <pre className="whitespace-pre-wrap font-sans text-sm leading-relaxed">
+              {markdown}
+            </pre>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/lib/careerotter/case-prompt.ts
+++ b/lib/careerotter/case-prompt.ts
@@ -1,0 +1,80 @@
+/**
+ * Promo case builder prompt (M4). Assembles the user's logged wins into a
+ * structured case document against a generic promo/raise rubric. The document
+ * reads like the user's own case: first person, zero otter personality (D: the
+ * character coaches, the deliverable is the user's). Voice guardrails still
+ * apply (no AI tells), but the register is the user's, not the mascot's.
+ */
+
+import { VOICE_GUARDRAILS } from "@/lib/ai/voice-guardrails";
+import { WIN_TAG_OPTIONS, type WinTag } from "@/lib/constants/careerotter";
+
+export const CASE_PROMPT_VERSION = "1.0.0";
+
+// Kept local so the case builder doesn't depend on the coach module (they ship
+// on independent branches). Shapes match the wins/career_profiles selections.
+export interface CaseProfile {
+  mode?: string | null;
+  role?: string | null;
+  level?: string | null;
+  target?: string | null;
+  review_date?: string | null;
+}
+
+export interface CaseWin {
+  text: string;
+  impact_number?: string | null;
+  tag?: string | null;
+  created_at?: string;
+}
+
+const TAG_LABEL: Record<WinTag, string> = Object.fromEntries(
+  WIN_TAG_OPTIONS.map((o) => [o.value, o.label])
+) as Record<WinTag, string>;
+
+// Generic promo-case rubric v1. Custom rubric upload is a fast follow (PRD M4).
+export const CASE_RUBRIC_V1 = [
+  "Summary: one paragraph stating the case for the raise or promotion.",
+  "Evidence by theme: group the wins by impact area (delivery, leadership, collaboration, craft). Lead each with the strongest, quantified where possible (situation, action, measurable result).",
+  "Impact: pull the hardest numbers into a short highlights list.",
+  "Gaps: name honestly what the case is still light on. One or two lines.",
+  "The ask: a direct, specific ask (the promotion/raise and why now).",
+];
+
+export function buildCasePrompt(
+  profile: CaseProfile | null,
+  wins: CaseWin[]
+): string {
+  const goal =
+    profile?.mode === "job_search"
+      ? "a stronger candidacy for their next role"
+      : profile?.mode === "raise"
+        ? "a raise"
+        : "a promotion";
+
+  const context: string[] = [`They are building the case for ${goal}.`];
+  if (profile?.role) context.push(`Role: ${profile.role}${profile.level ? `, ${profile.level}` : ""}.`);
+  if (profile?.target) context.push(`Target: ${profile.target}.`);
+  if (profile?.review_date) context.push(`Review date: ${profile.review_date}.`);
+
+  const winLines = wins
+    .map((w, i) => {
+      const tag = w.tag ? ` [${TAG_LABEL[w.tag as WinTag] ?? w.tag}]` : "";
+      const impact = w.impact_number ? ` (${w.impact_number})` : "";
+      return `${i + 1}. ${w.text}${impact}${tag}`;
+    })
+    .join("\n");
+
+  return `${VOICE_GUARDRAILS}
+
+Write a promotion/raise case document FROM THE USER, in their first-person voice. No mascot personality, no otter references, no coaching asides. This is the document they hand a manager or paste into a review. Use only the wins below as evidence; do not invent facts or numbers. Where a win lacks a number, keep it qualitative rather than fabricating one.
+
+Structure it as markdown with these sections, in order:
+${CASE_RUBRIC_V1.map((r, i) => `${i + 1}. ${r}`).join("\n")}
+
+Their context:
+${context.join("\n")}
+
+Their logged wins (the only evidence):
+${winLines || "None logged."}`;
+}


### PR DESCRIPTION
## M4 — Promo case builder / export

The payoff that justifies the subscription: the logged wins become the document. **Base is `careerotter/m2a-evidence-data`** — merge #184 first.

### What's here
- **Case API** (`POST /api/careerotter/case`) — Pro-gated. Grounded in the user's wins + goal via `buildCasePrompt` against a generic **promo rubric v1** (summary, evidence by theme, impact highlights, gaps acknowledged, the ask). **First-person, zero otter voice** — the deliverable is the user's, not the mascot's. Requires ≥3 wins (`422` otherwise); only cites logged evidence, never fabricates numbers. Fires `case_exported`.
- **Case prompt** (`lib/careerotter/case-prompt.ts`) — versioned, rubric exported, self-contained types so it ships independently of the coach module.
- **Case builder UI** (`/dashboard/review-prep`) — generate → **copy to clipboard**, **download markdown**, and **print (browser Save-as-PDF)**: the three exports the PRD asks for.

### Gates
- `pnpm test`: **104 suites / 1491 pass** (+1: case prompt + route).
- `npx tsc --noEmit`: **375 vs 374 baseline** (the +1 is the review-prep page's async-`NavigationServer`).

Custom-rubric upload (paste your company's ladder) is the documented fast follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)