### PR TITLE
CareerOtter Phase 2 · M2c — Zero-to-Case UI, recap cron, privacy/export

### DIFF
--- a/__tests__/api/careerotter-export.test.ts
+++ b/__tests__/api/careerotter-export.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for GET /api/careerotter/export (M2c privacy): auth + full payload shape.
+ */
+
+import { GET } from "@/app/api/careerotter/export/route";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin-client";
+
+jest.mock("@/lib/supabase/server", () => ({ createClient: jest.fn() }));
+jest.mock("@/lib/supabase/admin-client", () => ({ createAdminClient: jest.fn() }));
+
+const mockCreateClient = createClient as jest.Mock;
+const mockAdmin = createAdminClient as jest.Mock;
+const USER = { id: "user-1", email: "u@example.com" };
+
+function setUser(user: unknown) {
+  mockCreateClient.mockResolvedValue({
+    auth: { getUser: jest.fn().mockResolvedValue({ data: { user }, error: null }) },
+  });
+}
+
+// Table-aware mock: each from(table) returns a FRESH builder bound to that table
+// (so concurrent chains under Promise.all don't share state), awaitable to that
+// table's result.
+function adminWithTables(results: Record<string, { data: unknown; error: unknown }>) {
+  mockAdmin.mockReturnValue({
+    from(table: string) {
+      const builder: Record<string, unknown> = {};
+      for (const m of ["select", "eq", "order", "maybeSingle", "single"]) {
+        builder[m] = () => builder;
+      }
+      (builder as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+        resolve(results[table] ?? { data: null, error: null });
+      return builder;
+    },
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setUser(USER);
+});
+
+it("401 when unauthenticated", async () => {
+  setUser(null);
+  expect((await GET()).status).toBe(401);
+});
+
+it("returns a full export payload with an attachment header", async () => {
+  adminWithTables({
+    career_profiles: { data: { user_id: USER.id, mode: "promotion" }, error: null },
+    wins: { data: [{ id: "w1", text: "shipped it" }], error: null },
+    weekly_recaps: { data: [], error: null },
+    comp_entries: { data: [{ id: "c1", base: 150000 }], error: null },
+  });
+
+  const res = await GET();
+  expect(res.status).toBe(200);
+  expect(res.headers.get("Content-Disposition")).toMatch(/careerotter-export\.json/);
+
+  const body = JSON.parse(await res.text());
+  expect(body.user.id).toBe(USER.id);
+  expect(body.career_profile.mode).toBe("promotion");
+  expect(body.wins).toHaveLength(1);
+  expect(body.comp_entries).toHaveLength(1);
+  expect(body.exported_at).toBeTruthy();
+});

--- a/app/(app)/dashboard/data/page.tsx
+++ b/app/(app)/dashboard/data/page.tsx
@@ -1,0 +1,39 @@
+export const dynamic = "force-dynamic";
+
+import { redirect } from "next/navigation";
+import { NavigationServer } from "@/components/navigation-server";
+import { getUser } from "@/lib/supabase/server";
+import { DataExportButton } from "@/components/careerotter/data-export-button";
+
+/**
+ * Your data (CareerOtter M2c privacy posture). A plain-language statement plus
+ * one-click export. Users log employer-confidential material, so the posture is
+ * stated before we ask for it (RFC §5).
+ */
+export default async function DataPage() {
+  const user = await getUser();
+  if (!user) redirect("/login");
+
+  return (
+    <div className="min-h-screen bg-background">
+      <NavigationServer />
+      <main className="container mx-auto max-w-2xl px-4 py-8 space-y-6">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-bold">Your data</h1>
+          <p className="text-sm text-muted-foreground">
+            You are logging real work. Here is how we treat it.
+          </p>
+        </div>
+
+        <ul className="space-y-2 text-sm text-muted-foreground">
+          <li>Your wins, goals, recaps, and comp history are yours.</li>
+          <li>We do not train models on your data.</li>
+          <li>Export everything anytime, below.</li>
+          <li>Delete your account and it is gone, wins included.</li>
+        </ul>
+
+        <DataExportButton />
+      </main>
+    </div>
+  );
+}

--- a/app/(app)/dashboard/start/page.tsx
+++ b/app/(app)/dashboard/start/page.tsx
@@ -1,0 +1,31 @@
+export const dynamic = "force-dynamic";
+
+import { redirect } from "next/navigation";
+import { NavigationServer } from "@/components/navigation-server";
+import { getUser } from "@/lib/supabase/server";
+import { ZeroToCaseFlow } from "@/components/careerotter/zero-to-case-flow";
+
+/**
+ * Zero to Case onboarding (CareerOtter M2c). The first thing after signup: three
+ * questions, a generated starter case. Free once for everyone (the API enforces
+ * idempotency).
+ */
+export default async function StartPage() {
+  const user = await getUser();
+  if (!user) redirect("/login");
+
+  return (
+    <div className="min-h-screen bg-background">
+      <NavigationServer />
+      <main className="container mx-auto max-w-2xl px-4 py-8">
+        <div className="mb-6 space-y-1">
+          <h1 className="text-2xl font-bold">Start your case</h1>
+          <p className="text-sm text-muted-foreground">
+            Two minutes. You leave with a real first draft, not an empty journal.
+          </p>
+        </div>
+        <ZeroToCaseFlow />
+      </main>
+    </div>
+  );
+}

--- a/app/api/careerotter/export/route.ts
+++ b/app/api/careerotter/export/route.ts
@@ -1,0 +1,47 @@
+/**
+ * One-click data export (CareerOtter Phase 2, M2c privacy posture).
+ *
+ * GET /api/careerotter/export -> a JSON download of everything CareerOtter holds
+ * for the signed-in user: their goal frame, wins, weekly recaps, and comp
+ * history. "Export anytime" is part of the stated data posture before marketing
+ * to employed professionals (RFC §5).
+ */
+
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin-client";
+
+export async function GET() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const admin = createAdminClient();
+  const [profile, wins, recaps, comp] = await Promise.all([
+    admin.from("career_profiles").select("*").eq("user_id", user.id).maybeSingle(),
+    admin.from("wins").select("*").eq("user_id", user.id).order("created_at", { ascending: true }),
+    admin.from("weekly_recaps").select("*").eq("user_id", user.id).order("week_start", { ascending: true }),
+    admin.from("comp_entries").select("*").eq("user_id", user.id).order("effective_date", { ascending: true }),
+  ]);
+
+  const payload = {
+    exported_at: new Date().toISOString(),
+    user: { id: user.id, email: user.email },
+    career_profile: profile.data ?? null,
+    wins: wins.data ?? [],
+    weekly_recaps: recaps.data ?? [],
+    comp_entries: comp.data ?? [],
+  };
+
+  return new NextResponse(JSON.stringify(payload, null, 2), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Content-Disposition": 'attachment; filename="careerotter-export.json"',
+    },
+  });
+}

--- a/app/api/cron/careerotter-recap/route.ts
+++ b/app/api/cron/careerotter-recap/route.ts
@@ -1,0 +1,122 @@
+/**
+ * Weekly recap cron (CareerOtter Phase 2, M2c). Friday job: for each user who
+ * logged wins this week, generate a short recap they could paste into a 1:1 or
+ * review, and store it (the in-app return hook reads the latest one). Idempotent
+ * via weekly_recaps' unique (user_id, week_start).
+ *
+ * Email dispatch is intentionally NOT wired here: a new sending domain
+ * (careerotter.io) must be warmed with SPF/DKIM/DMARC first (M1 owner step).
+ * Once warmed, send the stored recap from this same job.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { verifyCronAuth } from "@/lib/email/lifecycle-cron";
+import { createAdminClient } from "@/lib/supabase/admin-client";
+import { callOpenAI } from "@/lib/openai/client";
+import { VOICE_GUARDRAILS } from "@/lib/ai/voice-guardrails";
+import { loggerService } from "@/lib/services/logger.service";
+import { LogCategory } from "@/lib/services/logger.types";
+
+export const maxDuration = 300;
+
+const ENDPOINT = "/api/cron/careerotter-recap";
+const MAX_USERS = 200; // Backstop for a runaway job; log if we hit it.
+const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
+
+/** Monday 00:00 UTC of the week containing `now` (YYYY-MM-DD). */
+function weekStartOf(now: Date): string {
+  const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const dow = d.getUTCDay(); // 0 Sun..6 Sat
+  const backToMonday = (dow + 6) % 7;
+  d.setUTCDate(d.getUTCDate() - backToMonday);
+  return d.toISOString().slice(0, 10);
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  if (!verifyCronAuth(request, ENDPOINT)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const now = new Date();
+  const weekStart = weekStartOf(now);
+  const windowStartIso = new Date(now.getTime() - MS_PER_WEEK).toISOString();
+  const admin = createAdminClient();
+
+  const { data: recentWins, error } = await admin
+    .from("wins")
+    .select("user_id, text, tag, impact_number")
+    .gte("created_at", windowStartIso);
+
+  if (error) {
+    loggerService.error("Recap cron: failed to load recent wins", error, {
+      category: LogCategory.BUSINESS,
+      action: "careerotter_recap_query_failed",
+    });
+    return NextResponse.json({ error: "query failed" }, { status: 500 });
+  }
+
+  // Group wins by user.
+  const byUser = new Map<string, { text: string; tag: string | null; impact_number: string | null }[]>();
+  for (const w of recentWins ?? []) {
+    const list = byUser.get(w.user_id) ?? [];
+    list.push({ text: w.text, tag: w.tag, impact_number: w.impact_number });
+    byUser.set(w.user_id, list);
+  }
+
+  const userIds = [...byUser.keys()];
+  const capped = userIds.length > MAX_USERS;
+  const toProcess = userIds.slice(0, MAX_USERS);
+  if (capped) {
+    loggerService.warn("Recap cron: user count exceeded cap; some skipped", {
+      category: LogCategory.BUSINESS,
+      action: "careerotter_recap_capped",
+      metadata: { total: userIds.length, cap: MAX_USERS },
+    });
+  }
+
+  let generated = 0;
+  for (const userId of toProcess) {
+    const wins = byUser.get(userId) ?? [];
+    try {
+      const winList = wins
+        .map((w, i) => `${i + 1}. ${w.text}${w.impact_number ? ` (${w.impact_number})` : ""}`)
+        .join("\n");
+      const text = await callOpenAI({
+        systemPrompt: VOICE_GUARDRAILS,
+        messages: [
+          {
+            role: "user",
+            content: `Here is what I shipped this week:\n${winList}\n\nWrite a short recap (3-5 sentences) I could paste into a 1:1 or review doc. First person, my voice, no otter personality. Use only these wins.`,
+          },
+        ],
+        maxTokens: 400,
+        temperature: 0.5,
+      });
+
+      const { error: upsertError } = await admin.from("weekly_recaps").upsert(
+        {
+          user_id: userId,
+          week_start: weekStart,
+          generated_text: text,
+          wins_included: wins.length,
+        },
+        { onConflict: "user_id,week_start" }
+      );
+      if (!upsertError) generated += 1;
+    } catch (err) {
+      loggerService.error("Recap cron: per-user generation failed", err, {
+        category: LogCategory.AI_SERVICE,
+        action: "careerotter_recap_user_failed",
+        metadata: { userId },
+      });
+    }
+  }
+
+  loggerService.info("Recap cron complete", {
+    category: LogCategory.BUSINESS,
+    action: "careerotter_recap_complete",
+    metadata: { weekStart, eligibleUsers: userIds.length, generated },
+  });
+
+  return NextResponse.json({ weekStart, eligibleUsers: userIds.length, generated });
+}

--- a/components/careerotter/data-export-button.tsx
+++ b/components/careerotter/data-export-button.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Download } from "lucide-react";
+
+/**
+ * One-click export (M2c privacy). Hits the export endpoint and triggers a file
+ * download of everything CareerOtter holds for the user.
+ */
+export function DataExportButton() {
+  return (
+    <Button variant="outline" asChild>
+      <a href="/api/careerotter/export" download="careerotter-export.json">
+        <Download className="mr-2 h-4 w-4" />
+        Export my data (JSON)
+      </a>
+    </Button>
+  );
+}

--- a/components/careerotter/zero-to-case-flow.tsx
+++ b/components/careerotter/zero-to-case-flow.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent } from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
+import { CAREER_MODE_OPTIONS, type CareerMode } from "@/lib/constants/careerotter";
+import { trackZeroToCaseStarted } from "@/lib/analytics/careerotter-events";
+
+/**
+ * Zero to Case onboarding (M2c). Three questions, about two minutes, and the AI
+ * drafts a starter case from what the user already remembers. They leave with a
+ * real document, not an empty journal (RFC §6). Skippable, but the skip is quiet.
+ */
+export function ZeroToCaseFlow({ prefillReviewDate }: { prefillReviewDate?: string }) {
+  const router = useRouter();
+  const [step, setStep] = useState(0);
+  const [mode, setMode] = useState<CareerMode>("promotion");
+  const [role, setRole] = useState("");
+  const [level, setLevel] = useState("");
+  const [reviewDate, setReviewDate] = useState(prefillReviewDate ?? "");
+  const [wins, setWins] = useState(["", "", ""]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+  const [starterCase, setStarterCase] = useState("");
+
+  const started = useRef(false);
+  useEffect(() => {
+    if (started.current) return;
+    started.current = true;
+    trackZeroToCaseStarted({ mode });
+  }, [mode]);
+
+  async function finish() {
+    setSubmitting(true);
+    setError("");
+    try {
+      const res = await fetch("/api/careerotter/zero-to-case", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          mode,
+          role: role || undefined,
+          level: level || undefined,
+          review_date: reviewDate || undefined,
+          wins: wins.map((w) => w.trim()).filter(Boolean),
+        }),
+      });
+      const data = await res.json().catch(() => null);
+      if (res.ok && data?.starterCase) {
+        setStarterCase(data.starterCase);
+        setStep(3);
+      } else {
+        setError(data?.error || "Could not build your starter case. Try again.");
+      }
+    } catch {
+      setError("Could not build your starter case. Try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (step === 3 && starterCase) {
+    return (
+      <div className="space-y-4">
+        <h2 className="text-lg font-semibold">Here's your starter case.</h2>
+        <Card>
+          <CardContent className="p-6">
+            <pre className="whitespace-pre-wrap font-sans text-sm leading-relaxed">
+              {starterCase}
+            </pre>
+          </CardContent>
+        </Card>
+        <div className="flex gap-2">
+          <Button onClick={() => router.push("/dashboard/wins")}>
+            Go to my wins
+          </Button>
+          <Button variant="outline" onClick={() => router.push("/dashboard/review-prep")}>
+            Build the full case
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {step === 0 && (
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold">What are you working toward?</h2>
+          <div className="grid gap-2">
+            {CAREER_MODE_OPTIONS.map((o) => (
+              <Button
+                key={o.value}
+                variant={mode === o.value ? "default" : "outline"}
+                className="justify-start"
+                onClick={() => setMode(o.value)}
+              >
+                {o.label}
+              </Button>
+            ))}
+          </div>
+          <Button onClick={() => setStep(1)}>Next</Button>
+        </div>
+      )}
+
+      {step === 1 && (
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold">A little about your role.</h2>
+          <div className="space-y-1.5">
+            <Label htmlFor="role">Role</Label>
+            <Input id="role" value={role} onChange={(e) => setRole(e.target.value)}
+              placeholder="e.g. Senior Engineer" className="min-h-[44px]" />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="level">Level / years in it</Label>
+              <Input id="level" value={level} onChange={(e) => setLevel(e.target.value)}
+                placeholder="e.g. 3 years" className="min-h-[44px]" />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="rd">Next review (optional)</Label>
+              <Input id="rd" type="date" value={reviewDate}
+                onChange={(e) => setReviewDate(e.target.value)} className="min-h-[44px]" />
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => setStep(0)}>Back</Button>
+            <Button onClick={() => setStep(2)}>Next</Button>
+          </div>
+        </div>
+      )}
+
+      {step === 2 && (
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold">
+            Name up to three things you shipped or fixed recently.
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Rough notes are fine. The AI shapes them into evidence.
+          </p>
+          {wins.map((w, i) => (
+            <Input
+              key={i}
+              value={w}
+              onChange={(e) => {
+                const next = [...wins];
+                next[i] = e.target.value;
+                setWins(next);
+              }}
+              placeholder={`Win ${i + 1}`}
+              className="min-h-[44px]"
+            />
+          ))}
+          {error && <p role="alert" className="text-sm text-destructive">{error}</p>}
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => setStep(1)} disabled={submitting}>
+              Back
+            </Button>
+            <Button onClick={finish} disabled={submitting}>
+              {submitting ? <><Spinner size="sm" className="mr-2" />Building…</> : "Build my starter case"}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={() => router.push("/dashboard/wins")}
+        className="text-xs text-muted-foreground underline-offset-2 hover:underline"
+      >
+        Skip for now
+      </button>
+    </div>
+  );
+}

--- a/vercel.json
+++ b/vercel.json
@@ -23,6 +23,10 @@
     {
       "path": "/api/cron/weekly-digest",
       "schedule": "0 13 * * 1"
+    },
+    {
+      "path": "/api/cron/careerotter-recap",
+      "schedule": "0 22 * * 5"
     }
   ]
 }


### PR DESCRIPTION
## M2c — Zero-to-Case UI, weekly recap, privacy/export

Completes the M2 evidence loop on top of M2a's API. **Base is `careerotter/m2a-evidence-data`** — merge #184 first.

### What's here
- **Zero to Case onboarding** (`/dashboard/start`) — three steps (fork → role → up to three wins) → `POST /api/careerotter/zero-to-case` → shows the generated starter case with next steps. The first thing after signup; quiet skip. Fires `ztc_started`.
- **Weekly recap cron** (`/api/cron/careerotter-recap`, Fri 22:00 UTC) — for each user who logged wins this week, generates a paste-ready recap (voice guardrails) and upserts `weekly_recaps` (idempotent). **Email dispatch is intentionally deferred** until careerotter.io sending is warmed (M1 owner step); the recap is generated and stored now, ready to send.
- **Privacy posture** (`/dashboard/data`) + **one-click export** (`GET /api/careerotter/export` → JSON of profile + wins + recaps + comp). Plain-language data page: it's yours, no training on it, export anytime, delete means delete (RFC §5).

### Gates
- `pnpm test`: **104 suites / 1488 pass** (+1: export route).
- `npx tsc --noEmit`: **376 vs 374 baseline** — the +2 is the two new pages' async-`NavigationServer` `TS2786` (established pattern).

With this, the PRD's M2 is complete: a user can sign up, leave day one with a starter case, log wins weekly, get a recap, and export a review-ready doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)