### PR TITLE
CareerOtter launch readiness — transition banner, rename email, evidence flag

### DIFF
--- a/.claude/ship/launch-readiness-PRD.md
+++ b/.claude/ship/launch-readiness-PRD.md
@@ -1,0 +1,247 @@
+# PRD — CareerOtter Launch Readiness Kit
+
+> Filename note: kept distinct from `phase2-PRD.md` / `phase2-TASKS.md` and any branch
+> `PRD.md` to avoid clobbering. Covers only launch-readiness deliverables, not the
+> Phase 2 feature work.
+
+## Scale context (drives every build/buy call below)
+
+Small user base: the Phase 0 validation email went to **95**; **3 Pro subscribers**
+today; 60-day target is 10. Total accounts are in the low hundreds at most. This makes
+per-device dismissal, a simple per-recipient sent-log, and a single-batch broadcast
+entirely adequate — no distributed idempotency, no cross-device preference store needed.
+
+## Problem Statement
+
+The AppTrack → CareerOtter conversion spans 10 open PRs (M0–M7). Three launch-critical
+gaps:
+
+1. **No existing-user heads-up in-app.** M1 rebrands strings/domain/templates and 301s
+   old URLs, but a logged-in user just sees the name change unexplained. The only rename
+   messaging that exists is inline on 301'd roast pages (`lib/rebrand-redirect.ts`).
+2. **No rename-announcement email.** `lib/email/` has broadcast infra (`sendBroadcast`,
+   audiences, Resend client) but no rename template or send path. Given low DAU for a
+   job-search app, **email is the primary reach channel; the banner is the secondary,
+   for-when-they-return channel.** Both are needed.
+3. **The product switch isn't wired.** The rollout plan depends on one
+   `careerotter_evidence` flag to gate net-new surfaces (M2b–M5, M7 nav). It doesn't
+   exist in `FEATURE_FLAGS` yet.
+
+Out of scope but noted: brand strings inside Stripe receipts/billing surfaces are
+owner-managed in Stripe, not in this repo.
+
+## Goals
+
+- G1: A dismissible, accessible, app-shell transition banner ("AppTrack is now
+  CareerOtter"), shown only to existing users, only during a **fixed 30-day window**,
+  with dismissal persisted (per-device) so it never nags. Emits PostHog shown/dismissed.
+- G2: A rename-announcement broadcast email — branded template + owner-triggered send
+  path that is **safe by construction**: dry-run default, real send requires TWO
+  independent guards and refuses outside production. Honors unsubscribe; CAN-SPAM
+  compliant; per-recipient sent-log prevents double-send on re-run.
+- G3: The `careerotter_evidence` flag **primitive** exists (canonical key, client hook +
+  one server helper, both default **false** through a single fallback). Wiring into
+  M2b–M5 surfaces is explicitly **NOT** delivered here (those branches are unmerged);
+  it's tracked per-PR in the rollout plan.
+- G4: A launch-readiness **audit doc**, stamped with an as-of commit SHA + timestamp,
+  produced **read-only** against GitHub: per-PR unresolved-thread/CI/mergeable status +
+  gating status → a go/no-go checklist that must be re-run immediately before launch.
+
+## Non-Goals (hard scope limits — load-bearing, enforced by defaults + tests, not prose)
+
+- **NOT merging the 10 PRs.** No `gh pr merge`, no pushes to `main`.
+- **NOT performing the domain/infra cutover** (DNS, Vercel env, SPF/DKIM/DMARC,
+  `careerotter.io` go-live) — owner-only (M1.6).
+- **NOT sending the bulk email.** Real send requires `NODE_ENV=production` AND
+  `ALLOW_REAL_SEND=1` (env) AND an explicit `confirm` param — refuses if any is missing,
+  and refuses entirely in CI/non-production. Dry-run is the default and the only path
+  this workflow exercises.
+- **NOT flipping `careerotter_evidence` (or the banner) on in any environment.** No
+  committed config enables either; every environment default ships **OFF**, asserted by
+  a unit test. Rollout % is set in PostHog by the owner on launch day.
+- **NOT wiring the flag into M2b–M5 surfaces** (unmerged branches).
+- **NOT re-doing M1's rebrand.** All three rename surfaces (roast redirect, banner,
+  email) pull their headline/explainer copy from **one shared constant**
+  (`lib/constants/rebrand-copy.ts`) — no divergent wording.
+- **The readiness audit is READ-ONLY against GitHub** — no thread resolution, no
+  comments, no status changes. Uses the read-only `gh` account (do NOT `gh auth switch`
+  to the write account for the audit).
+
+## User Stories
+
+- As an **existing user**, after the rename I want a clear "AppTrack is now CareerOtter —
+  same account, same data, same login" banner I can dismiss, so I'm not confused.
+- As a **user who dismissed the banner (on this device)**, I don't want to see it again
+  here. (v1 dismissal is per-device — acceptable at this user scale; see Risks.)
+- As a **user who signed up after the cutover instant**, I never see the banner.
+- As the **owner**, I want to preview the email (rendered, no SMTP), see the real
+  audience count, and send one live test to myself before any real send — so I can't
+  blast a broken/mis-branded email during a fragile cutover.
+- As the **owner**, I want a timestamped go/no-go report (threads resolved? surfaces
+  gated?) so I launch on evidence.
+
+## Technical Approach
+
+Lands on a **dedicated branch off `main`** (`careerotter/launch-readiness`), NOT on the
+M0 pricing PR.
+
+**Shared copy source (Non-Goal enforcement):** `lib/constants/rebrand-copy.ts` exports
+the headline, sub, and "why the new name?" explainer + link. Banner, email, and (ideally)
+the roast redirect import it.
+
+**Banner (G1):**
+- Component mounts in the logged-in app shell (`app/(app)/layout.tsx` — confirm this is
+  the sole authed shell in Task 1; note fallback if multiple).
+- Eligibility computed **server-side**: `isExistingUser = user.created_at < CUTOVER_AT`,
+  where `REBRAND_CUTOVER_AT` is a **server-only** env (NOT `NEXT_PUBLIC_`). The only
+  public toggle is `NEXT_PUBLIC_REBRAND_BANNER` (on/off for the 30-day window). Both must
+  be true to render. Mid-cutover signups (created ≥ CUTOVER_AT) are treated as new.
+- Dismissal: **localStorage** key `ff:rebrand-banner-dismissed` (per-device; matches the
+  existing `ff:*` local-override convention). No migration, no per-request DB read on the
+  hot path. Dismiss is optimistic and client-only; never blocks render.
+- A11y acceptance: `role="status"`, close button is a real `<button>` (44px), keyboard-
+  focusable, dismissible via Esc, visible focus ring, WCAG AA contrast. Banner overlays a
+  reserved-height slot (no CLS) rather than pushing layout mid-paint.
+- UI rules (CLAUDE.md): no emojis, no gradient text, Tailwind only.
+- Emits `capturePostHogEvent("rebrand_banner_shown" | "rebrand_banner_dismissed")`.
+
+**Rename email (G2):**
+- Template `lib/email/templates/rebrand-announcement.ts`, shaped like `templates/shared.ts`
+  siblings. Plain-language; imports shared copy; includes unsubscribe link + physical
+  mailing address (CAN-SPAM).
+- **Send from the warmed `apptrack.ing` domain**, not fresh `careerotter.io` — announcing
+  a domain change from a cold domain tanks deliverability. `from`/`replyTo` read from a
+  send-time constant, asserted to match the expected warmed domain or the real send refuses.
+- Send path reuses `sendBroadcast` + `getSubscribedMembers(audience)` (already filters
+  unsubscribes). Trigger via a guarded admin route matching the existing admin-route auth
+  (confirm the exact guard in Task 2; require a test that unauthenticated/non-admin → 401/403).
+- **Idempotency:** a per-recipient sent-log (small table or a marker on the existing
+  broadcast/preferences store) checked before each send; a re-run after a crash skips
+  already-sent addresses. Batch with basic backoff; resumable via the sent-log cursor.
+- **Guards:** `dryRun` default true → renders + returns audience count + optionally one
+  live test to the owner, no mass SMTP. Real send requires `NODE_ENV=production` +
+  `ALLOW_REAL_SEND=1` + `confirm:true`; refuses otherwise. Emits `email_broadcast_sent`.
+
+**Gating primitive (G3):**
+- `FEATURE_FLAGS.CAREEROTTER_EVIDENCE = "careerotter-evidence"` (hyphenated value to match
+  existing keys like `"dashboard-ux-audit-v1"`; PostHog flag key must be byte-identical).
+  Banner window flag: `"careerotter-rebrand-banner"` if we prefer a flag over env — pick
+  one in Task 3; do not define both.
+- One shared resolver both the client hook and a new `lib/analytics/posthog-server.ts`
+  helper call; fallback is **`false`** on `undefined`/error/no-user. Server helper takes an
+  explicit distinct-id (the session user id); no user → `false`. Unit test asserts
+  `undefined → false`.
+
+**Readiness audit (G4):** `phase2-LAUNCH-CHECKLIST.md`, header = as-of SHA + timestamp +
+"re-run before go/no-go." A table over #182–#191: unresolved review-thread count, CI
+conclusion, mergeable state — enumerable states only, **no per-thread remediation**.
+Plus gating status and owner-only launch steps. GitHub reads are read-only.
+
+## Edge Cases & Risks (each has a test or an explicit accepted-risk)
+
+- **Banner to new users** → server-side `created_at < CUTOVER_AT` (server-only env). TEST:
+  post-cutover user → no banner.
+- **Banner outlives window** → `NEXT_PUBLIC_REBRAND_BANNER` off hides it regardless of
+  account age. TEST: toggle off → no banner. Teardown owner task with a due date (below).
+- **Dismissal cross-device** → ACCEPTED RISK at this scale (per-device). User story
+  amended to "on this device." Owner sign-off noted.
+- **Dismissal write failure** → N/A (localStorage, client-only, optimistic). Never blocks render.
+- **Email double-send on re-run** → per-recipient sent-log checked before send. TEST:
+  re-run after partial send skips delivered addresses.
+- **Real send fires by accident** → three independent guards + refuses in non-prod/CI.
+  TEST: `confirm` alone without env guards → refuses; CI env → refuses.
+- **Deliverability during cutover** → send from warmed `apptrack.ing`; `FROM_EMAIL`/sender
+  asserted at real-send or refuse. Bounce/complaint suppression via `getSubscribedMembers`
+  + owner precondition "warmup done." Documented owner precondition.
+- **CAN-SPAM** → template includes unsubscribe + physical address; audience filter runs in
+  the send path. TEST: template contains unsubscribe token + address.
+- **Admin send route abuse** → same admin guard as existing admin routes; enforced auth
+  (CSRF/same-origin via existing pattern). TEST: unauth → rejected.
+- **Flag default-on leak (Vercel preview inherits env)** → defaults OFF in code; unit test
+  asserts `undefined → false`; no committed env enables it. Per-environment values owner-set.
+- **Flag key typo (hyphen/underscore)** → single canonical constant; PostHog key must match.
+- **Server flag with no user context** → returns `false`.
+- **Banner copy overflow on mobile** → constrained copy length; responsive; 44px close.
+- **Audit goes stale** → stamped SHA + "re-run before launch"; read-only.
+
+## Observability
+
+`capturePostHogEvent` for `rebrand_banner_shown`, `rebrand_banner_dismissed`,
+`email_broadcast_sent` (with recipient count, dryRun flag). Lets the owner confirm the
+launch mechanisms fired.
+
+## Teardown (nothing is permanent)
+
+- Banner: owner sets `NEXT_PUBLIC_REBRAND_BANNER=off` at window end (**due: cutover + 30
+  days**); a follow-up task removes the component + env after.
+- Flag: after `careerotter_evidence` is 100% and stable, remove flag checks + dead
+  branches.
+- Email: irreversible once sent — the only truly one-way action; hence the triple guard.
+
+## Test Plan (acceptance tests, one per guarantee)
+
+1. Banner: existing user + window on → renders; new user → not; window off → not.
+2. Banner: dismiss persists across reload (same device).
+3. Email: dry-run sends 0 mass mail, returns correct audience count.
+4. Email: real-send guards — missing any of the three → refuses; CI → refuses.
+5. Email: re-run skips already-sent recipients (sent-log).
+6. Email: admin route rejects unauthenticated/non-admin.
+7. Flag: resolver returns `false` on undefined/error/no-user (client + server).
+8. Copy: banner + email import the shared `rebrand-copy` constant (no literals).
+
+## Open Questions (resolved — recorded for traceability)
+
+- OQ1 dismissal persistence → **localStorage (per-device)**, justified by scale.
+- OQ2 send trigger → **guarded admin route** matching existing admin-route auth (confirm
+  exact guard in Task 2).
+- OQ3 cutover timestamp → **server-only env `REBRAND_CUTOVER_AT`**; public toggle is a
+  separate on/off env. Reconciles the server-side-eligibility requirement.
+- OQ4 logged-out existing users → **app shell only** for v1; 301 roast copy + rebranded
+  marketing serve the logged-out path. Owner may extend later. (Flagged for owner confirm.)
+
+## Revision Notes (critic critiques → resolutions)
+
+- **Existing-user count missing / possible over-engineering** → Added Scale Context (~95
+  emailed, 3 Pro, low hundreds). Simplified: localStorage dismissal, single-batch send,
+  simple sent-log — no cross-device store, no distributed idempotency.
+- **Email is likely the primary channel (low DAU), banner secondary** → Stated explicitly
+  in Problem #2; both retained.
+- **"Bounded window" never bounded** → Fixed 30-day window + explicit off-switch env +
+  teardown task with due date.
+- **G3 conflates "flag exists" with "launch switch"** → Reworded: primitive only, wiring
+  NOT delivered here, tracked per-PR.
+- **G4 audit stale / not independent** → Stamped as-of SHA + timestamp + "re-run before
+  go/no-go"; read-only against GitHub; read-only gh account.
+- **Non-Goals bound actions not config** → Added: no committed config enables banner/flag
+  in any env, defaults OFF asserted by test; real send needs prod + `ALLOW_REAL_SEND=1` +
+  `confirm` and refuses in CI/non-prod; audit read-only (no thread writes).
+- **Divergent rename copy in 3 places** → Single source `lib/constants/rebrand-copy.ts`.
+- **`NEXT_PUBLIC_` cutover timestamp leaks to client / invites client-side eligibility** →
+  Cutover timestamp is server-only; only the on/off toggle is public.
+- **Mid-cutover signup ambiguity** → Cutover is a single fixed instant; ≥ instant = new.
+- **Dismissal data model undecided / hot-path DB read / write-failure handling** →
+  localStorage resolves all three (no DB read, optimistic, never blocks).
+- **A11y underspecified** → Enumerated: role=status, keyboard/Esc dismiss, focus ring,
+  AA, no CLS.
+- **Email idempotency hand-waved** → Per-recipient sent-log checked before send; resumable.
+- **No batching/partial-failure** → Basic batch + backoff + sent-log cursor.
+- **Dry-run still hits SMTP from risky domain** → Dry-run renders without mass SMTP;
+  optional single live test; send from warmed apptrack.ing.
+- **Admin auth unspecified / CSRF** → Matches existing admin-route guard; test unauth
+  rejected; same-origin/enforced token.
+- **CAN-SPAM footer** → Unsubscribe + physical address required; tested.
+- **`FROM_EMAIL` unguarded at send** → Asserted to expected warmed domain or refuse.
+- **Bounce/suppression** → via `getSubscribedMembers`; owner warmup precondition.
+- **Announcing domain change trips spam filters** → Send from warmed domain; noted risk.
+- **Flag default-off split across two systems** → Single resolver, fallback false, unit
+  tested; server helper needs explicit distinct-id, no-user → false.
+- **Flag key hyphen/underscore inconsistency** → Canonical hyphenated value, one constant.
+- **Audit scope creep / gh account gotcha** → Table of enumerable states only; read-only
+  account; no writes.
+- **Risks defer their own mitigations** → Each risk now maps to a test or an explicit
+  accepted-risk with sign-off.
+- **Env vars leaking to preview** → Added risk + default-off test.
+- **No rollback/teardown** → Teardown section added.
+- **No test plan** → Test Plan section added.
+- **No observability** → Observability section added.
+- **OQ1/OQ2 consequential, left open** → Resolved in Open Questions above.

--- a/.claude/ship/launch-readiness-PRD.md
+++ b/.claude/ship/launch-readiness-PRD.md
@@ -62,7 +62,7 @@ owner-managed in Stripe, not in this repo.
 - **NOT wiring the flag into M2b–M5 surfaces** (unmerged branches).
 - **NOT re-doing M1's rebrand.** All three rename surfaces (roast redirect, banner,
   email) pull their headline/explainer copy from **one shared constant**
-  (`lib/constants/rebrand-copy.ts`) — no divergent wording.
+  (`lib/constants/rebrand.ts`) — no divergent wording.
 - **The readiness audit is READ-ONLY against GitHub** — no thread resolution, no
   comments, no status changes. Uses the read-only `gh` account (do NOT `gh auth switch`
   to the write account for the audit).
@@ -85,7 +85,7 @@ owner-managed in Stripe, not in this repo.
 Lands on a **dedicated branch off `main`** (`careerotter/launch-readiness`), NOT on the
 M0 pricing PR.
 
-**Shared copy source (Non-Goal enforcement):** `lib/constants/rebrand-copy.ts` exports
+**Shared copy source (Non-Goal enforcement):** `lib/constants/rebrand.ts` exports
 the headline, sub, and "why the new name?" explainer + link. Banner, email, and (ideally)
 the roast redirect import it.
 
@@ -187,7 +187,7 @@ launch mechanisms fired.
 5. Email: re-run skips already-sent recipients (sent-log).
 6. Email: admin route rejects unauthenticated/non-admin.
 7. Flag: resolver returns `false` on undefined/error/no-user (client + server).
-8. Copy: banner + email import the shared `rebrand-copy` constant (no literals).
+8. Copy: banner + email import the shared `rebrand` constant (`lib/constants/rebrand.ts`) (no literals).
 
 ## Open Questions (resolved — recorded for traceability)
 
@@ -215,7 +215,7 @@ launch mechanisms fired.
 - **Non-Goals bound actions not config** → Added: no committed config enables banner/flag
   in any env, defaults OFF asserted by test; real send needs prod + `ALLOW_REAL_SEND=1` +
   `confirm` and refuses in CI/non-prod; audit read-only (no thread writes).
-- **Divergent rename copy in 3 places** → Single source `lib/constants/rebrand-copy.ts`.
+- **Divergent rename copy in 3 places** → Single source `lib/constants/rebrand.ts`.
 - **`NEXT_PUBLIC_` cutover timestamp leaks to client / invites client-side eligibility** →
   Cutover timestamp is server-only; only the on/off toggle is public.
 - **Mid-cutover signup ambiguity** → Cutover is a single fixed instant; ≥ instant = new.

--- a/.claude/ship/launch-readiness-TASKS.md
+++ b/.claude/ship/launch-readiness-TASKS.md
@@ -1,0 +1,52 @@
+# Task Breakdown — CareerOtter Launch Readiness Kit
+
+Branch: `careerotter/launch-readiness` off `main` (NOT the M0 pricing PR).
+Stack: Next.js 15 App Router · TS · Jest (`pnpm test`) · `pnpm lint` · type: `npx tsc --noEmit` (no NEW errors vs baseline).
+
+## Task 1: Shared rename copy + in-app transition banner
+- [x] 1.1: Confirm `app/(app)/layout.tsx` is the sole authed shell (note fallback if multiple authed layouts).
+- [x] 1.2: Create `lib/constants/rebrand-copy.ts` — single source for headline ("AppTrack is now CareerOtter"), sub ("Same account, same data, same login"), and "Why the new name?" explainer + link.
+- [x] 1.3: Build `components/rebrand-banner.tsx` (+ server eligibility wrapper). Render only when `NEXT_PUBLIC_REBRAND_BANNER==="on"` AND server-side `user.created_at < REBRAND_CUTOVER_AT` (server-only env). Mount in the authed shell. Dismissal via `localStorage` `ff:rebrand-banner-dismissed` (optimistic, client-only, never blocks render). Import copy from 1.2.
+- [x] 1.4: A11y + UI: `role="status"`, real 44px `<button>` close, Esc-dismiss, focus ring, WCAG AA, no CLS (reserved-height slot), no emojis/gradient text. Emit `capturePostHogEvent("rebrand_banner_shown"/"rebrand_banner_dismissed")`.
+- [x] 1.5: Write tests for Task 1 — eligibility matrix (existing+window-on → shows; new user → hidden; window off → hidden); dismissal persists across reload; copy comes from the shared constant.
+
+## Task 2: Rename-announcement broadcast email (safe by construction)
+- [x] 2.1: Confirm admin-route auth + send pattern by reading `app/api/admin/career-validation-email/route.ts` and `lib/email/broadcast.ts` (`sendBroadcast`, `getSubscribedMembers`, `AudienceId`).
+- [x] 2.2: Create `lib/email/templates/rebrand-announcement.ts` — imports shared copy (1.2); plain-language; includes unsubscribe link + physical mailing address (CAN-SPAM). Sender = warmed `apptrack.ing` domain, read from constant.
+- [x] 2.3: Create `app/api/admin/rebrand-email/route.ts` mirroring the existing admin-auth guard. `dryRun` default true → renders + returns audience count + optional single live test to owner, NO mass SMTP. Real send requires `NODE_ENV==="production"` AND `ALLOW_REAL_SEND==="1"` AND `confirm===true`; refuse otherwise (and always in CI/non-prod). Assert sender domain matches expected or refuse.
+- [x] 2.4: Idempotency — per-recipient sent-log (marker checked before each send); re-run skips delivered addresses; batch with basic backoff; resumable via cursor. Emit `email_broadcast_sent` (count, dryRun).
+- [x] 2.5: Write tests for Task 2 — dry-run sends 0 mass mail + correct count; real-send guard refuses when any of the 3 conditions missing and in CI; re-run skips already-sent; admin route rejects unauth/non-admin; template contains unsubscribe token + physical address.
+
+## Task 3: `careerotter_evidence` flag primitive (default-off)
+- [x] 3.1: Add `CAREEROTTER_EVIDENCE: "careerotter-evidence"` to `FEATURE_FLAGS` (hyphenated to match existing keys). Decide banner-window as env (chosen) — do NOT also add a banner flag.
+- [x] 3.2: Single resolver used by both the client `useFeatureFlag` path and a new server helper in `lib/analytics/posthog-server.ts`; fallback `false` on undefined/error/no-user; server helper takes explicit session user id.
+- [x] 3.3: Write tests for Task 3 — resolver returns `false` on undefined/error/no-user (client + server); flag key string matches the canonical constant.
+
+## Task 4: Launch-readiness audit doc (read-only)
+- [x] 4.1: Read-only query (use read-only `gh` account; NO writes/comments/resolves) of unresolved review-thread count, CI conclusion, and mergeable state for PRs #182–#191.
+- [x] 4.2: Write `.claude/ship/phase2-LAUNCH-CHECKLIST.md` — header stamped with as-of commit SHA + timestamp + "re-run before go/no-go"; table of enumerable PR states; gating status (which surfaces wrapped); owner-only launch steps (domain, env, flag %, email send). No per-thread remediation.
+- [x] 4.3: Validation subtask — verify the table matches live PR state at write time and that the doc makes no write to GitHub (audit is analysis; no unit test, this is the dedicated verification).
+
+## Task 5: Doc accuracy — env vars
+- [x] 5.1: Add to `.env.example` (with comments): `REBRAND_CUTOVER_AT` (server-only ISO instant), `NEXT_PUBLIC_REBRAND_BANNER` (on/off), `ALLOW_REAL_SEND` (gate for real email send). Note `FROM_EMAIL` should point at the warmed sender for the announcement.
+- [x] 5.2: Validation — grep `.env.example` contains the three new keys; no other docs reference them incorrectly.
+
+## Known owner-only (NOT in this workflow — checklist output only)
+- Merge the 10 PRs (order per `phase2-ROLLOUT.md`).
+- Domain/DNS/Vercel env/SPF-DKIM-DMARC + `careerotter.io` go-live.
+- Flip `careerotter_evidence` rollout % in PostHog.
+- Trigger the real rename email (after domain warmup).
+
+## Known trade-offs (from code review, accepted)
+
+- **Empty audience burns the campaign marker** (route.ts): marker-first idempotency
+  means a real send fired against an empty audience records "sent" with 0 recipients and
+  needs `force:true` to retry. Kept — this matches the proven `career-validation-email`
+  pattern; the alternative (marker-after-send) reintroduces double-send risk. Response
+  clearly shows `sent:0`.
+- **`force` resend overwrites `recipient_count`/`metadata`** (route.ts): a scoped retry
+  resets the analytics count. Low severity — the count is analytics-only for this
+  one-time campaign, not a gate. Kept for pattern-consistency with the career route.
+- **Substring sender guard** (`from.includes('apptrack.ing')`): accepts a crafted
+  look-alike domain. Kept — `REBRAND_FROM` is owner-set env; there is no adversary in the
+  single-operator threat model.

--- a/.claude/ship/launch-readiness-TASKS.md
+++ b/.claude/ship/launch-readiness-TASKS.md
@@ -5,7 +5,7 @@ Stack: Next.js 15 App Router · TS · Jest (`pnpm test`) · `pnpm lint` · type:
 
 ## Task 1: Shared rename copy + in-app transition banner
 - [x] 1.1: Confirm `app/(app)/layout.tsx` is the sole authed shell (note fallback if multiple authed layouts).
-- [x] 1.2: Create `lib/constants/rebrand-copy.ts` — single source for headline ("AppTrack is now CareerOtter"), sub ("Same account, same data, same login"), and "Why the new name?" explainer + link.
+- [x] 1.2: Create `lib/constants/rebrand.ts` — single source for headline ("AppTrack is now CareerOtter"), sub ("Same account, same data, same login"), and "Why the new name?" explainer + link.
 - [x] 1.3: Build `components/rebrand-banner.tsx` (+ server eligibility wrapper). Render only when `NEXT_PUBLIC_REBRAND_BANNER==="on"` AND server-side `user.created_at < REBRAND_CUTOVER_AT` (server-only env). Mount in the authed shell. Dismissal via `localStorage` `ff:rebrand-banner-dismissed` (optimistic, client-only, never blocks render). Import copy from 1.2.
 - [x] 1.4: A11y + UI: `role="status"`, real 44px `<button>` close, Esc-dismiss, focus ring, WCAG AA, no CLS (reserved-height slot), no emojis/gradient text. Emit `capturePostHogEvent("rebrand_banner_shown"/"rebrand_banner_dismissed")`.
 - [x] 1.5: Write tests for Task 1 — eligibility matrix (existing+window-on → shows; new user → hidden; window off → hidden); dismissal persists across reload; copy comes from the shared constant.

--- a/.claude/ship/phase2-LAUNCH-CHECKLIST.md
+++ b/.claude/ship/phase2-LAUNCH-CHECKLIST.md
@@ -1,0 +1,63 @@
+# CareerOtter Phase 2 — Launch Go/No-Go Checklist
+
+> **As of:** 2026-08-03T22:39:20Z · base `origin/main` @ `78f089e`
+> **Snapshot — RE-RUN before launch.** PR state changes continuously; a stale
+> checklist reads "ready" after it no longer is. Regenerate the table below
+> (read-only `gh`) immediately before flipping anything.
+
+## Verdict: NOT READY TO SHIP
+
+Two gate conditions from the ship request:
+
+1. **"All PR feedback addressed" — ❌ FALSE.** 20 unresolved review threads remain
+   across 3 PRs (#183: 15, #184: 4, #190: 1). Must be resolved or explicitly waived.
+2. **"Properly gated" — ⚠️ PARTIAL.** The `careerotter_evidence` flag primitive now
+   exists and defaults OFF, but it is **not yet wired** into the M2b–M5 surfaces
+   (those branches are unmerged). Wiring happens per-PR at merge. Until then, flipping
+   the flag does nothing — there is no working switch yet.
+
+## PR state (snapshot)
+
+| PR | Milestone | Mergeable | Failing checks | Unresolved threads | Ready? |
+|----|-----------|-----------|----------------|--------------------|--------|
+| #182 | M0 pricing | ✅ | 0 | 0 | ✅ ready |
+| #183 | M1 rebrand | ✅ | 0 | **15** | ❌ feedback |
+| #184 | M2a evidence data/API | ✅ | 0 | **4** | ❌ feedback |
+| #185 | M2b evidence UI | ✅ | 0 | 0 | ⚠️ needs flag wiring |
+| #186 | M3 coach | ✅ | 0 | 0 | ⚠️ needs flag wiring |
+| #187 | M4 case builder | ✅ | 0 | 0 | ⚠️ needs flag wiring |
+| #188 | M5 comp tracker | ✅ | 0 | 0 | ⚠️ needs flag wiring |
+| #189 | M2c ZtC/recap/privacy | ✅ | 0 | 0 | ⚠️ needs flag wiring |
+| #190 | M6 visual identity | ✅ | 0 | **1** | ❌ feedback |
+| #191 | M7 nav/IA | ✅ | 0 | 0 | ⚠️ needs flag wiring |
+
+## Blocking work before launch
+
+- [ ] Resolve the 15 unresolved threads on **#183 (M1 rebrand)** — the highest-risk PR
+      (domain, strings, emails, 301s).
+- [ ] Resolve the 4 unresolved threads on **#184 (M2a)**.
+- [ ] Resolve the 1 unresolved thread on **#190 (M6)**.
+- [ ] Wire `careerotter_evidence` into the entry points of #185–#189 and the #191 nav as
+      each merges (client `useFeatureFlag` / server `getServerFeatureFlag`, default OFF).
+- [ ] Re-run this audit; confirm all three feedback PRs show 0 unresolved.
+
+## Owner-only launch steps (after the above is green)
+
+1. Merge order per `phase2-ROLLOUT.md`: M0 → M2a → M2b/M3/M4/M5/M2c (flag OFF) → M6 →
+   M7 → **M1 rebrand last**.
+2. Domain cutover: point `careerotter.io`, set Vercel env per environment (incl.
+   `NEXT_PUBLIC_APP_URL`, `REBRAND_CUTOVER_AT`), SPF/DKIM/DMARC, warm the sending domain.
+3. Turn on the transition banner: set `NEXT_PUBLIC_REBRAND_BANNER=on` and
+   `NEXT_PUBLIC_REBRAND_CUTOVER_AT` to the real cutover instant.
+4. Send the rename email — only after domain warmup:
+   - Dry-run: `POST /api/admin/rebrand-email` (returns audience counts, no send).
+   - Test: `{ "testEmail": "you@..." }` (one live email to yourself).
+   - Real: set `ALLOW_REAL_SEND=1` in production, then `{ "confirm": true }`.
+5. Ramp `careerotter_evidence` in PostHog (10% → 50% → 100%), watching the funnels.
+6. Retire the banner at cutover + 30 days (`NEXT_PUBLIC_REBRAND_BANNER=off`).
+
+## Audit method (read-only)
+
+Per-PR `gh pr view --json mergeable,statusCheckRollup` + a GraphQL `reviewThreads`
+count where `isResolved=false`. No writes, no comments, no thread resolution. Uses the
+read-only `gh` account (do not `gh auth switch` for the audit).

--- a/.claude/ship/phase2-LAUNCH-CHECKLIST.md
+++ b/.claude/ship/phase2-LAUNCH-CHECKLIST.md
@@ -1,45 +1,59 @@
 # CareerOtter Phase 2 — Launch Go/No-Go Checklist
 
-> **As of:** 2026-08-03T22:39:20Z · base `origin/main` @ `78f089e`
+> **As of:** 2026-08-04T01:33:04Z · base `origin/main` @ `78f089e`
 > **Snapshot — RE-RUN before launch.** PR state changes continuously; a stale
 > checklist reads "ready" after it no longer is. Regenerate the table below
 > (read-only `gh`) immediately before flipping anything.
 
-## Verdict: NOT READY TO SHIP
+## Verdict: NOT READY — but the review-feedback gate is nearly clear
 
-Two gate conditions from the ship request:
-
-1. **"All PR feedback addressed" — ❌ FALSE.** 20 unresolved review threads remain
-   across 3 PRs (#183: 15, #184: 4, #190: 1). Must be resolved or explicitly waived.
-2. **"Properly gated" — ⚠️ PARTIAL.** The `careerotter_evidence` flag primitive now
-   exists and defaults OFF, but it is **not yet wired** into the M2b–M5 surfaces
-   (those branches are unmerged). Wiring happens per-PR at merge. Until then, flipping
-   the flag does nothing — there is no working switch yet.
+1. **"All PR feedback addressed" — ⚠️ NEARLY.** 34 CodeRabbit threads were triaged
+   and resolved across #183/#184/#190/#192. **4 remain, all owner-decisions** (no clear
+   code fix — they need your call): #183 ×3, #192 ×1. See "Owner decisions" below.
+2. **"Properly gated" — ⚠️ PARTIAL (by design).** The `careerotter-evidence` flag now
+   exists in PostHog (id 797754, **disabled, 0% rollout** → evaluates false everywhere).
+   It is intentionally **not yet wired** into the M2b–M5 surfaces — that happens per-PR
+   as those branches merge onto M2a (wiring an unmerged branch just creates merge churn).
 
 ## PR state (snapshot)
 
 | PR | Milestone | Mergeable | Failing checks | Unresolved threads | Ready? |
 |----|-----------|-----------|----------------|--------------------|--------|
 | #182 | M0 pricing | ✅ | 0 | 0 | ✅ ready |
-| #183 | M1 rebrand | ✅ | 0 | **15** | ❌ feedback |
-| #184 | M2a evidence data/API | ✅ | 0 | **4** | ❌ feedback |
-| #185 | M2b evidence UI | ✅ | 0 | 0 | ⚠️ needs flag wiring |
-| #186 | M3 coach | ✅ | 0 | 0 | ⚠️ needs flag wiring |
-| #187 | M4 case builder | ✅ | 0 | 0 | ⚠️ needs flag wiring |
-| #188 | M5 comp tracker | ✅ | 0 | 0 | ⚠️ needs flag wiring |
-| #189 | M2c ZtC/recap/privacy | ✅ | 0 | 0 | ⚠️ needs flag wiring |
-| #190 | M6 visual identity | ✅ | 0 | **1** | ❌ feedback |
-| #191 | M7 nav/IA | ✅ | 0 | 0 | ⚠️ needs flag wiring |
+| #183 | M1 rebrand | ✅ | 0 | **3 (owner-decision)** | ⚠️ decisions |
+| #184 | M2a evidence data/API | ✅ | 0 | 0 | ✅ feedback clear |
+| #185 | M2b evidence UI | ✅ | 0 | 0 | ⚠️ flag wiring at merge |
+| #186 | M3 coach | ✅ | 0 | 0 | ⚠️ flag wiring at merge |
+| #187 | M4 case builder | ✅ | 0 | 0 | ⚠️ flag wiring at merge |
+| #188 | M5 comp tracker | ✅ | 0 | 0 | ⚠️ flag wiring at merge |
+| #189 | M2c ZtC/recap/privacy | ✅ | 0 | 0 | ⚠️ flag wiring at merge |
+| #190 | M6 visual identity | ✅ | 0 | 0 | ✅ feedback clear |
+| #191 | M7 nav/IA | ✅ | 0 | 0 | ⚠️ flag wiring at merge |
+| #192 | Launch-readiness kit | ✅ | 0 | **1 (owner-decision)** | ⚠️ decision |
 
-## Blocking work before launch
+## Owner decisions (block full "feedback addressed" — need your call)
 
-- [ ] Resolve the 15 unresolved threads on **#183 (M1 rebrand)** — the highest-risk PR
-      (domain, strings, emails, 301s).
-- [ ] Resolve the 4 unresolved threads on **#184 (M2a)**.
-- [ ] Resolve the 1 unresolved thread on **#190 (M6)**.
-- [ ] Wire `careerotter_evidence` into the entry points of #185–#189 and the #191 nav as
-      each merges (client `useFeatureFlag` / server `getServerFeatureFlag`, default OFF).
-- [ ] Re-run this audit; confirm all three feedback PRs show 0 unresolved.
+- **#183 — webhook `APP_URL` precedence** (`stripe/webhook/route.ts:675`): drop the
+  runtime `APP_URL` fallback repo-wide, or keep the deliberate `getAppUrl` pattern? The
+  fix must be consistent app-wide, not just the webhook.
+- **#183 — centralize the canonical origin** (`auth.ts` + ~11 files, heavy lift): real
+  duplication with subtly different env precedence (`APP_URL` / `VERCEL_URL` / none).
+  Scope this refactor or defer.
+- **#183 — Zero-to-Case idempotency failure-safety** (M2a design): the marker-first
+  claim is race-safe but not failure-safe (model call failing after the claim leaves a
+  completed marker with no case). Pending/completed states vs transaction vs compensating
+  retry — a design call.
+- **#192 — banner client-side eligibility** (`rebrand-banner.tsx`): reads `created_at`
+  via `useSupabaseAuth` (touches CLAUDE.md "no Supabase in client components"). Keep the
+  app-wide client-auth pattern, or rework to server/API-resolved eligibility?
+
+## Remaining path
+
+- [ ] Owner: decide the 4 items above (I implement whatever you choose).
+- [ ] Merge in ROLLOUT order; wire `careerotter-evidence` into #185–#189 + #191 entry
+      points **as each merges** onto M2a (client `useFeatureFlag` / server
+      `getServerFeatureFlag`, default OFF).
+- [ ] Re-run this audit immediately before launch.
 
 ## Owner-only launch steps (after the above is green)
 

--- a/.claude/ship/phase2-ROLLOUT.md
+++ b/.claude/ship/phase2-ROLLOUT.md
@@ -15,12 +15,12 @@ on + set one flag to 100%," and everything else has already landed dark.
 
 ## Flag inventory
 
-- `careerotter_evidence` (PostHog, add to `FEATURE_FLAGS`) — gates every net-new
+- `careerotter-evidence` (PostHog, add to `FEATURE_FLAGS`) — gates every net-new
   surface: M2b evidence UI, M3 coach, M4 case builder, M5 comp, M2c Zero-to-Case
   onboarding, and the M7 nav entries that point at them. This is THE switch.
   - Client `useFeatureFlag` hides UI. The real access boundary stays `isPro()`
     server-side for AI features — keep it; the flag is for surfacing, not security.
-  - localStorage override (`ff:careerotter_evidence`) already lets you dogfood locally.
+  - localStorage override (`ff:careerotter-evidence`) already lets you dogfood locally.
 - No flag for M0 pricing, M1 rebrand, M2a data, M6 visual (see below).
 
 ## PR disposition
@@ -29,40 +29,45 @@ on + set one flag to 100%," and everything else has already landed dark.
 |----|-----------|-------------|-----|
 | #182 | M0 pricing | **Dark-merge, live** | `isPro` grandfathers everyone; pricing page is brand-neutral and reflects the now-live $9/$90. DB repriced (done). |
 | #184 | M2a evidence data/API | **Dark-merge** | Inert — new tables/routes with no entry point. |
-| #185 | M2b evidence UI | **Flag** `careerotter_evidence` | Net-new surface. Stacked on M2a. |
+| #185 | M2b evidence UI | **Flag** `careerotter-evidence` | Net-new surface. Stacked on M2a. |
 | #186 | M3 coach | **Flag** | Net-new surface. Stacked on M2a. |
 | #187 | M4 case builder | **Flag** | Net-new surface. Stacked on M2a. |
 | #188 | M5 comp tracker | **Flag** | Net-new surface. Stacked on M2a. |
 | #189 | M2c ZtC/recap/privacy | **Flag** (cron/privacy page can be live) | Onboarding surface behind flag; recap cron + privacy page are safe live. |
 | #190 | M6 visual identity | **Dark-merge or cutover** | Global theme; cosmetic. Ship when brand cutover lands, or earlier if standalone. |
-| #191 | M7 nav/IA | **Flag** (couple to `careerotter_evidence`) | New nav must only expose surfaces that are on. |
+| #191 | M7 nav/IA | **Flag** (couple to `careerotter-evidence`) | New nav must only expose surfaces that are on. |
 | #183 | M1 rebrand | **CUTOVER (last)** | Domain/env/OG/sitemap/email/301s are deploy-time. Launch-day event. |
 
 ## Merge order
 
 1. **#182 M0** → `main`. Ships live; grandfathers all. (DB reprice already applied.)
 2. **#184 M2a** → `main`. Dark/inert.
-3. Add `careerotter_evidence` to `FEATURE_FLAGS`; wrap entry points as each lands.
+3. Add `careerotter-evidence` to `FEATURE_FLAGS`; wrap entry points as each lands.
 4. **#185 / #186 / #187 / #188 / #189** → `main`, in stack order, all flagged OFF.
 5. **#190 M6** visual → `main` (with or just before the cutover).
 6. **#191 M7** nav → `main`, gated by the same flag.
 7. **#183 M1 rebrand** → `main` last, held for launch day.
 
 By step 6, ~everything is on `main` and in prod, invisible. Launch = flip the domain
-+ set the flag to 100%.
++ set the `careerotter-evidence` flag to 100%.
 
 ## Launch day
 
 1. Deploy the rebrand cutover (domain live, env vars set, 301s from apptrack.ing).
-2. Verify: old URLs 301 correctly, roast permalinks + OG on new host, emails send
-   from the new domain.
-3. Set `careerotter_evidence` to 100% (or ramp: 10% → 50% → 100% watching PostHog
+2. Verify: old URLs 301 correctly, roast permalinks + OG on new host, and general
+   transactional email sends from the new careerotter.io domain.
+3. Send the rename announcement (`POST /api/admin/rebrand-email`, dry-run → test →
+   `confirm`). NOTE: this one email deliberately sends from the **warmed apptrack.ing**
+   domain, not careerotter.io — announcing a domain change from a cold domain tanks
+   deliverability. Migrating this campaign's sender to careerotter.io is a separate,
+   later step once the new domain is warmed.
+4. Set `careerotter-evidence` to 100% (or ramp: 10% → 50% → 100% watching PostHog
    funnels: signup → ZtC complete → first win → week-2 return).
-4. Confirm a fresh signup hits Zero-to-Case and the new surfaces.
+5. Confirm a fresh signup hits Zero-to-Case and the new surfaces.
 
 ## Post-launch cleanup
 
-- Once `careerotter_evidence` is 100% and stable, remove the flag checks and the
+- Once `careerotter-evidence` is 100% and stable, remove the flag checks and the
   dead branches (both sides of every `useFeatureFlag`).
 - Archive the retired Stripe product/prices after the transition (owner).
 - Later: the deferred `AI Coach -> "Pro"` DB rename + move display constants off the

--- a/.claude/ship/phase2-ROLLOUT.md
+++ b/.claude/ship/phase2-ROLLOUT.md
@@ -1,0 +1,77 @@
+# CareerOtter Phase 2 — Merge & Rollout Plan
+
+Goal: merge 10 PRs to `main` without a big-bang, so launch day is "turn the domain
+on + set one flag to 100%," and everything else has already landed dark.
+
+## Principle: merge ≠ activate
+
+- **Dark-merge** anything backward-compatible or inert — it lands on `main` and
+  ships to prod with zero user-visible change.
+- **Flag** the net-new product surfaces behind ONE product flag.
+- **Cutover** the rebrand as a coordinated launch event (domain + deploy), NOT a
+  per-user flag — a half-flagged brand is incoherent.
+- Don't flag billing or brand. Flags are code you must test on both sides and clean
+  up; only flag what de-risks launch.
+
+## Flag inventory
+
+- `careerotter_evidence` (PostHog, add to `FEATURE_FLAGS`) — gates every net-new
+  surface: M2b evidence UI, M3 coach, M4 case builder, M5 comp, M2c Zero-to-Case
+  onboarding, and the M7 nav entries that point at them. This is THE switch.
+  - Client `useFeatureFlag` hides UI. The real access boundary stays `isPro()`
+    server-side for AI features — keep it; the flag is for surfacing, not security.
+  - localStorage override (`ff:careerotter_evidence`) already lets you dogfood locally.
+- No flag for M0 pricing, M1 rebrand, M2a data, M6 visual (see below).
+
+## PR disposition
+
+| PR | Milestone | Disposition | Why |
+|----|-----------|-------------|-----|
+| #182 | M0 pricing | **Dark-merge, live** | `isPro` grandfathers everyone; pricing page is brand-neutral and reflects the now-live $9/$90. DB repriced (done). |
+| #184 | M2a evidence data/API | **Dark-merge** | Inert — new tables/routes with no entry point. |
+| #185 | M2b evidence UI | **Flag** `careerotter_evidence` | Net-new surface. Stacked on M2a. |
+| #186 | M3 coach | **Flag** | Net-new surface. Stacked on M2a. |
+| #187 | M4 case builder | **Flag** | Net-new surface. Stacked on M2a. |
+| #188 | M5 comp tracker | **Flag** | Net-new surface. Stacked on M2a. |
+| #189 | M2c ZtC/recap/privacy | **Flag** (cron/privacy page can be live) | Onboarding surface behind flag; recap cron + privacy page are safe live. |
+| #190 | M6 visual identity | **Dark-merge or cutover** | Global theme; cosmetic. Ship when brand cutover lands, or earlier if standalone. |
+| #191 | M7 nav/IA | **Flag** (couple to `careerotter_evidence`) | New nav must only expose surfaces that are on. |
+| #183 | M1 rebrand | **CUTOVER (last)** | Domain/env/OG/sitemap/email/301s are deploy-time. Launch-day event. |
+
+## Merge order
+
+1. **#182 M0** → `main`. Ships live; grandfathers all. (DB reprice already applied.)
+2. **#184 M2a** → `main`. Dark/inert.
+3. Add `careerotter_evidence` to `FEATURE_FLAGS`; wrap entry points as each lands.
+4. **#185 / #186 / #187 / #188 / #189** → `main`, in stack order, all flagged OFF.
+5. **#190 M6** visual → `main` (with or just before the cutover).
+6. **#191 M7** nav → `main`, gated by the same flag.
+7. **#183 M1 rebrand** → `main` last, held for launch day.
+
+By step 6, ~everything is on `main` and in prod, invisible. Launch = flip the domain
++ set the flag to 100%.
+
+## Launch day
+
+1. Deploy the rebrand cutover (domain live, env vars set, 301s from apptrack.ing).
+2. Verify: old URLs 301 correctly, roast permalinks + OG on new host, emails send
+   from the new domain.
+3. Set `careerotter_evidence` to 100% (or ramp: 10% → 50% → 100% watching PostHog
+   funnels: signup → ZtC complete → first win → week-2 return).
+4. Confirm a fresh signup hits Zero-to-Case and the new surfaces.
+
+## Post-launch cleanup
+
+- Once `careerotter_evidence` is 100% and stable, remove the flag checks and the
+  dead branches (both sides of every `useFeatureFlag`).
+- Archive the retired Stripe product/prices after the transition (owner).
+- Later: the deferred `AI Coach -> "Pro"` DB rename + move display constants off the
+  `AI_COACH` keys (not required for launch; `isPro` is name-agnostic).
+
+## Open risks
+
+- **Stacked PRs (#185–189 on M2a):** merge M2a first, then the stack in order, or
+  collapse via the integration branch. Resolve conflicts against the M2a that lands.
+- **New API routes without server-side flagging** are reachable by URL even when the
+  UI is hidden. Fine for soft launch (AI routes still gate on `isPro`); add
+  server-side flag checks (`posthog-server.ts`) only if you need hard gating.

--- a/__tests__/api/rebrand-email.test.ts
+++ b/__tests__/api/rebrand-email.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Tests for POST /api/admin/rebrand-email.
+ *
+ * Covers the send-safety contract: auth rejection, warmed-domain + verified-
+ * sender guards, dry-run-by-default (counts only), the CAN-SPAM postal-address
+ * requirement, the triple real-send guard (prod + ALLOW_REAL_SEND + confirm),
+ * testEmail single-send, and marker-first idempotency.
+ */
+
+jest.mock("@/lib/email/lifecycle-cron", () => ({
+  verifyCronAuth: jest.fn(() => true),
+}));
+
+jest.mock("@/lib/email/broadcast", () => ({
+  sendBroadcast: jest.fn(),
+  getAudienceCount: jest.fn(),
+}));
+
+jest.mock("@/lib/supabase/admin-client", () => ({
+  createAdminClient: jest.fn(),
+}));
+
+jest.mock("@/lib/analytics/posthog-server", () => ({
+  captureServerEvent: jest.fn(),
+}));
+
+jest.mock("@/lib/services/logger.service", () => ({
+  loggerService: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/admin/rebrand-email/route";
+import { verifyCronAuth } from "@/lib/email/lifecycle-cron";
+import { sendBroadcast, getAudienceCount } from "@/lib/email/broadcast";
+import { createAdminClient } from "@/lib/supabase/admin-client";
+import { REBRAND_CAMPAIGN } from "@/lib/constants/rebrand";
+
+const mockVerify = verifyCronAuth as jest.MockedFunction<typeof verifyCronAuth>;
+const mockSend = sendBroadcast as jest.MockedFunction<typeof sendBroadcast>;
+const mockCount = getAudienceCount as jest.MockedFunction<typeof getAudienceCount>;
+const mockAdmin = createAdminClient as jest.MockedFunction<typeof createAdminClient>;
+
+// NODE_ENV is typed readonly; define it so the real-send guard can be exercised.
+function setNodeEnv(value: string | undefined) {
+  Object.defineProperty(process.env, "NODE_ENV", { value, configurable: true, writable: true });
+}
+
+function req(body: Record<string, unknown> = {}): NextRequest {
+  return new NextRequest("http://localhost/api/admin/rebrand-email", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function setupSupabase(insertError: { code: string } | null = null) {
+  const insert = jest.fn().mockResolvedValue({ error: insertError });
+  const upsert = jest.fn().mockResolvedValue({ error: null });
+  const updateEq = jest.fn().mockResolvedValue({ error: null });
+  const update = jest.fn(() => ({ eq: updateEq }));
+  const client = { from: jest.fn(() => ({ insert, upsert, update })) };
+  mockAdmin.mockReturnValue(client as never);
+  return { insert, upsert };
+}
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockVerify.mockReturnValue(true);
+  process.env.REBRAND_FROM = "Jordan at AppTrack <jordan@apptrack.ing>";
+  process.env.REBRAND_REPLY_TO = "jordan@apptrack.ing";
+  process.env.COMPANY_POSTAL_ADDRESS = "123 Main St, Springfield, IL 62704";
+  delete process.env.ALLOW_REAL_SEND;
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("POST /api/admin/rebrand-email", () => {
+  it("401s when auth fails", async () => {
+    mockVerify.mockReturnValue(false);
+    const res = await POST(req());
+    expect(res.status).toBe(401);
+  });
+
+  it("dry-runs by default: returns audience counts, sends nothing", async () => {
+    mockCount.mockResolvedValue(10);
+    const res = await POST(req());
+    const json = await res.json();
+    expect(json.dryRun).toBe(true);
+    expect(json.total).toBe(40); // 4 audiences x 10
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it("500s if the sender is not the warmed apptrack.ing domain", async () => {
+    process.env.REBRAND_FROM = "CareerOtter <jordan@careerotter.io>";
+    const res = await POST(req());
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toMatch(/warmed apptrack\.ing/);
+  });
+
+  it("500s if the sender is still Resend's test address", async () => {
+    process.env.REBRAND_FROM = "AppTrack <onboarding@resend.dev>";
+    const res = await POST(req());
+    expect(res.status).toBe(500);
+  });
+
+  it("refuses a real send outside production even with confirm", async () => {
+    process.env.ALLOW_REAL_SEND = "1"; // prod still missing
+    const res = await POST(req({ confirm: true }));
+    expect(res.status).toBe(403);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it("refuses a real send in production without ALLOW_REAL_SEND", async () => {
+    const prev = process.env.NODE_ENV;
+    setNodeEnv("production");
+    const res = await POST(req({ confirm: true }));
+    setNodeEnv(prev);
+    expect(res.status).toBe(403);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it("refuses a testEmail outside the env guard (no live mail from CI/preview/dev)", async () => {
+    const res = await POST(req({ testEmail: "me@example.com" }));
+    expect(res.status).toBe(403);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it("rejects an ambiguous testEmail + confirm combination", async () => {
+    const res = await POST(req({ confirm: true, testEmail: "me@example.com" }));
+    expect(res.status).toBe(400);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it("dryRun:true forces the count path even when confirm is also set", async () => {
+    const prev = process.env.NODE_ENV;
+    setNodeEnv("production");
+    process.env.ALLOW_REAL_SEND = "1";
+    mockCount.mockResolvedValue(3);
+    const res = await POST(req({ dryRun: true, confirm: true, audiences: ["leads"] }));
+    setNodeEnv(prev);
+    const json = await res.json();
+    expect(json.dryRun).toBe(true);
+    expect(json.total).toBe(3);
+    expect(mockSend).not.toHaveBeenCalled();
+    expect(mockAdmin).not.toHaveBeenCalled();
+  });
+
+  it("500s a guarded testEmail when the postal address is missing (CAN-SPAM)", async () => {
+    const prev = process.env.NODE_ENV;
+    setNodeEnv("production");
+    process.env.ALLOW_REAL_SEND = "1";
+    delete process.env.COMPANY_POSTAL_ADDRESS;
+    const res = await POST(req({ testEmail: "me@example.com" }));
+    setNodeEnv(prev);
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toMatch(/COMPANY_POSTAL_ADDRESS/);
+  });
+
+  it("sends a single guarded testEmail without a marker", async () => {
+    const prev = process.env.NODE_ENV;
+    setNodeEnv("production");
+    process.env.ALLOW_REAL_SEND = "1";
+    mockSend.mockResolvedValue({ audience: "leads", total: 1, sent: 1, failed: 0, sentRecipients: [] });
+    const res = await POST(req({ testEmail: "me@example.com" }));
+    setNodeEnv(prev);
+    const json = await res.json();
+    expect(json.sent).toBe(1);
+    expect(mockSend).toHaveBeenCalledWith(expect.objectContaining({ testEmail: "me@example.com" }));
+    expect(mockAdmin).not.toHaveBeenCalled(); // no campaign marker for a test
+  });
+
+  it("real send (prod + ALLOW_REAL_SEND + confirm) claims the marker and broadcasts", async () => {
+    const prev = process.env.NODE_ENV;
+    setNodeEnv("production");
+    process.env.ALLOW_REAL_SEND = "1";
+    const { insert } = setupSupabase();
+    mockSend.mockResolvedValue({ audience: "leads", total: 5, sent: 5, failed: 0, sentRecipients: [] });
+
+    const res = await POST(req({ confirm: true, audiences: ["leads"] }));
+    setNodeEnv(prev);
+
+    const json = await res.json();
+    expect(insert).toHaveBeenCalledWith(expect.objectContaining({ campaign: REBRAND_CAMPAIGN }));
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    expect(json.sent).toBe(5);
+  });
+
+  it("409s when the campaign marker already exists", async () => {
+    const prev = process.env.NODE_ENV;
+    setNodeEnv("production");
+    process.env.ALLOW_REAL_SEND = "1";
+    setupSupabase({ code: "23505" });
+
+    const res = await POST(req({ confirm: true, audiences: ["leads"] }));
+    setNodeEnv(prev);
+
+    expect(res.status).toBe(409);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it("400s on an invalid audience", async () => {
+    const res = await POST(req({ audiences: ["not-an-audience"] }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/__tests__/api/rebrand-email.test.ts
+++ b/__tests__/api/rebrand-email.test.ts
@@ -72,6 +72,9 @@ beforeEach(() => {
   process.env.REBRAND_REPLY_TO = "jordan@apptrack.ing";
   process.env.COMPANY_POSTAL_ADDRESS = "123 Main St, Springfield, IL 62704";
   delete process.env.ALLOW_REAL_SEND;
+  // The send guard refuses when CI is set; clear it so real-send tests exercise
+  // the actual path even when this suite itself runs on a CI runner.
+  delete process.env.CI;
 });
 
 afterEach(() => {
@@ -118,6 +121,17 @@ describe("POST /api/admin/rebrand-email", () => {
     const prev = process.env.NODE_ENV;
     setNodeEnv("production");
     const res = await POST(req({ confirm: true }));
+    setNodeEnv(prev);
+    expect(res.status).toBe(403);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it("refuses a real send when CI is set, even with prod + ALLOW_REAL_SEND", async () => {
+    const prev = process.env.NODE_ENV;
+    setNodeEnv("production");
+    process.env.ALLOW_REAL_SEND = "1";
+    process.env.CI = "1";
+    const res = await POST(req({ confirm: true, audiences: ["leads"] }));
     setNodeEnv(prev);
     expect(res.status).toBe(403);
     expect(mockSend).not.toHaveBeenCalled();

--- a/__tests__/components/rebrand-banner.test.tsx
+++ b/__tests__/components/rebrand-banner.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Tests for the AppTrack -> CareerOtter transition banner.
+ *
+ * Contract: shown only to existing users (created before the cutover) while the
+ * window env is "on" and it hasn't been dismissed on this device; hidden for new
+ * users, when the window is off, and after dismissal (persisted to localStorage).
+ */
+
+jest.mock("@/hooks/use-supabase-auth", () => ({
+  useSupabaseAuth: jest.fn(),
+}));
+
+jest.mock("@/lib/analytics/posthog", () => ({
+  capturePostHogEvent: jest.fn(),
+}));
+
+// next/link is globally mocked in jest.setup.js. The global lucide-react mock
+// there has a fixed icon list that omits X, so mock the icon this component uses.
+jest.mock("lucide-react", () => ({
+  X: () => <span data-testid="x-icon" />,
+}));
+
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { RebrandBanner } from "@/components/rebrand-banner";
+import { useSupabaseAuth } from "@/hooks/use-supabase-auth";
+import { capturePostHogEvent } from "@/lib/analytics/posthog";
+import { REBRAND_COPY } from "@/lib/constants/rebrand";
+
+const mockUseAuth = useSupabaseAuth as jest.MockedFunction<typeof useSupabaseAuth>;
+const mockCapture = capturePostHogEvent as jest.MockedFunction<typeof capturePostHogEvent>;
+
+const CUTOVER = "2026-08-01T00:00:00.000Z";
+const BEFORE = "2026-07-01T00:00:00.000Z";
+const AFTER = "2026-08-15T00:00:00.000Z";
+
+function mockUser(createdAt: string) {
+  mockUseAuth.mockReturnValue({ user: { created_at: createdAt }, loading: false } as never);
+}
+
+describe("RebrandBanner", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    process.env.NEXT_PUBLIC_REBRAND_BANNER = "on";
+    process.env.NEXT_PUBLIC_REBRAND_CUTOVER_AT = CUTOVER;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("shows for an existing user during the window and fires the shown event", async () => {
+    mockUser(BEFORE);
+    render(<RebrandBanner />);
+    expect(await screen.findByText(REBRAND_COPY.headline)).toBeInTheDocument();
+    await waitFor(() => expect(mockCapture).toHaveBeenCalledWith("rebrand_banner_shown"));
+  });
+
+  it("hides for a user created at/after the cutover", async () => {
+    mockUser(AFTER);
+    render(<RebrandBanner />);
+    await waitFor(() => {
+      expect(screen.queryByText(REBRAND_COPY.headline)).not.toBeInTheDocument();
+    });
+  });
+
+  it("hides when the window env is not 'on'", async () => {
+    process.env.NEXT_PUBLIC_REBRAND_BANNER = "off";
+    mockUser(BEFORE);
+    render(<RebrandBanner />);
+    await waitFor(() => {
+      expect(screen.queryByText(REBRAND_COPY.headline)).not.toBeInTheDocument();
+    });
+  });
+
+  it("hides when already dismissed on this device", async () => {
+    localStorage.setItem("ff:rebrand-banner-dismissed", "true");
+    mockUser(BEFORE);
+    render(<RebrandBanner />);
+    await waitFor(() => {
+      expect(screen.queryByText(REBRAND_COPY.headline)).not.toBeInTheDocument();
+    });
+  });
+
+  it("dismiss hides the banner, persists, and fires the dismissed event", async () => {
+    mockUser(BEFORE);
+    render(<RebrandBanner />);
+    await screen.findByText(REBRAND_COPY.headline);
+
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText(REBRAND_COPY.headline)).not.toBeInTheDocument();
+    });
+    expect(localStorage.getItem("ff:rebrand-banner-dismissed")).toBe("true");
+    expect(mockCapture).toHaveBeenCalledWith("rebrand_banner_dismissed");
+  });
+
+  it("hides when no user is authenticated", async () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: false } as never);
+    render(<RebrandBanner />);
+    await waitFor(() => {
+      expect(screen.queryByText(REBRAND_COPY.headline)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/lib/careerotter-evidence-flag.test.ts
+++ b/__tests__/lib/careerotter-evidence-flag.test.ts
@@ -1,0 +1,46 @@
+/**
+ * The careerotter_evidence flag is the single switch that will gate every
+ * net-new surface. This locks two invariants: the canonical key string, and
+ * default-OFF on both the client hook and the server helper when PostHog is
+ * unavailable — so a missing/erroring flag can never expose half-built surfaces.
+ */
+
+jest.mock("posthog-js/react", () => ({
+  usePostHog: jest.fn(() => null),
+}));
+
+import { renderHook } from "@testing-library/react";
+import { FEATURE_FLAGS, useFeatureFlag } from "@/lib/hooks/use-feature-flag";
+import { getServerFeatureFlag } from "@/lib/analytics/posthog-server";
+
+describe("careerotter_evidence flag", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("uses the canonical hyphenated PostHog key", () => {
+    expect(FEATURE_FLAGS.CAREEROTTER_EVIDENCE).toBe("careerotter-evidence");
+  });
+
+  it("client hook returns false when PostHog is unavailable", () => {
+    const { result } = renderHook(() => useFeatureFlag(FEATURE_FLAGS.CAREEROTTER_EVIDENCE));
+    expect(result.current).toBe(false);
+  });
+
+  it("server helper returns false when PostHog is not configured", async () => {
+    delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+    delete process.env.NEXT_PUBLIC_FF_CAREEROTTER_EVIDENCE;
+    await expect(
+      getServerFeatureFlag("user-123", FEATURE_FLAGS.CAREEROTTER_EVIDENCE)
+    ).resolves.toBe(false);
+  });
+
+  it("server helper honors an explicit env override of false", async () => {
+    process.env.NEXT_PUBLIC_FF_CAREEROTTER_EVIDENCE = "false";
+    await expect(
+      getServerFeatureFlag("user-123", FEATURE_FLAGS.CAREEROTTER_EVIDENCE)
+    ).resolves.toBe(false);
+  });
+});

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,4 +1,5 @@
 import { Footer } from "@/components/footer";
+import { RebrandBanner } from "@/components/rebrand-banner";
 
 export default function AppLayout({
   children,
@@ -7,6 +8,7 @@ export default function AppLayout({
 }) {
   return (
     <>
+      <RebrandBanner />
       {children}
       <Footer />
     </>

--- a/app/api/admin/rebrand-email/route.ts
+++ b/app/api/admin/rebrand-email/route.ts
@@ -79,7 +79,12 @@ function parseAudiences(raw: unknown): AudienceId[] | null {
 }
 
 function realSendAllowed(): boolean {
-  return process.env.NODE_ENV === 'production' && process.env.ALLOW_REAL_SEND === '1';
+  // Refuse in CI even if NODE_ENV/ALLOW_REAL_SEND happen to be set on the runner.
+  return (
+    !process.env.CI &&
+    process.env.NODE_ENV === 'production' &&
+    process.env.ALLOW_REAL_SEND === '1'
+  );
 }
 
 type MarkerClaim = 'claimed' | 'already-sent' | 'error';

--- a/app/api/admin/rebrand-email/route.ts
+++ b/app/api/admin/rebrand-email/route.ts
@@ -1,0 +1,308 @@
+/**
+ * AppTrack -> CareerOtter rename announcement — owner-triggered broadcast.
+ *
+ * POST /api/admin/rebrand-email
+ * Authorization: Bearer <CRON_SECRET> (owner-triggered admin route; the
+ * CRON_SECRET reuse is the same single-operator trade-off as the other admin
+ * email routes).
+ *
+ * Body (every field defaults to the SAFE path — dry run):
+ *   dryRun?     — informational; a real send is gated on `confirm`, not this.
+ *   confirm?    — must be boolean true to attempt a real broadcast.
+ *   testEmail?  — send one live test to this address (no marker, no events).
+ *   audiences?  — subset of leads/free-users/trial-users/paid-users.
+ *   force?      — upsert over an existing campaign marker to resend.
+ *
+ * Real-send guard (all three required, else refused): NODE_ENV==="production"
+ * AND ALLOW_REAL_SEND==="1" AND confirm===true. This route refuses to mass-send
+ * anywhere else, so the announcement can't fire from CI, preview, or a dev shell.
+ *
+ * Idempotency: the campaign_sends marker (PK on `campaign`) is written before
+ * any mail goes out; a second trigger hits a unique violation instead of
+ * double-blasting the list.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyCronAuth } from '@/lib/email/lifecycle-cron';
+import { getAudienceCount, sendBroadcast } from '@/lib/email/broadcast';
+import type { BroadcastResult, SentRecipient } from '@/lib/email/broadcast';
+import type { AudienceId } from '@/lib/email/audiences';
+import { createAdminClient } from '@/lib/supabase/admin-client';
+import { REBRAND_CAMPAIGN } from '@/lib/constants/rebrand';
+import {
+  DEFAULT_REBRAND_FROM,
+  DEFAULT_REBRAND_REPLY_TO,
+  REBRAND_ANNOUNCEMENT_SUBJECT,
+  getRebrandAnnouncementHtml,
+} from '@/lib/email/templates/rebrand-announcement';
+import { captureServerEvent } from '@/lib/analytics/posthog-server';
+import { loggerService } from '@/lib/services/logger.service';
+import { LogCategory } from '@/lib/services/logger.types';
+
+export const maxDuration = 300;
+
+const ENDPOINT = '/api/admin/rebrand-email';
+
+const VALID_AUDIENCES: readonly AudienceId[] = ['leads', 'free-users', 'trial-users', 'paid-users'];
+const DEFAULT_AUDIENCES: AudienceId[] = [...VALID_AUDIENCES];
+
+// The announcement must go out from the WARMED sending domain, never the fresh
+// careerotter.io (which would tank deliverability) or Resend's test address.
+const EXPECTED_SENDER_DOMAIN = 'apptrack.ing';
+
+const PG_UNIQUE_VIOLATION = '23505';
+
+type RequestBody = {
+  dryRun?: unknown;
+  confirm?: unknown;
+  testEmail?: unknown;
+  audiences?: unknown;
+  force?: unknown;
+};
+
+type AdminSupabaseClient = ReturnType<typeof createAdminClient>;
+
+function parseAudiences(raw: unknown): AudienceId[] | null {
+  if (raw === undefined) {
+    return DEFAULT_AUDIENCES;
+  }
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return null;
+  }
+  const allValid = raw.every((audience): audience is AudienceId =>
+    (VALID_AUDIENCES as readonly string[]).includes(audience)
+  );
+  if (!allValid) {
+    return null;
+  }
+  return [...new Set(raw as AudienceId[])];
+}
+
+function realSendAllowed(): boolean {
+  return process.env.NODE_ENV === 'production' && process.env.ALLOW_REAL_SEND === '1';
+}
+
+type MarkerClaim = 'claimed' | 'already-sent' | 'error';
+
+async function claimCampaignMarker(
+  supabase: AdminSupabaseClient,
+  audiences: AudienceId[],
+  force: boolean
+): Promise<MarkerClaim> {
+  const row = {
+    campaign: REBRAND_CAMPAIGN,
+    sent_at: new Date().toISOString(),
+    recipient_count: 0,
+    metadata: { audiences },
+  };
+
+  const { error } = force
+    ? await supabase.from('campaign_sends').upsert(row, { onConflict: 'campaign' })
+    : await supabase.from('campaign_sends').insert(row);
+
+  if (!error) {
+    return 'claimed';
+  }
+  if (error.code === PG_UNIQUE_VIOLATION) {
+    return 'already-sent';
+  }
+
+  loggerService.error('Failed to write rebrand campaign marker', error, {
+    category: LogCategory.EMAIL,
+    action: 'rebrand_email_marker_failed',
+    metadata: { campaign: REBRAND_CAMPAIGN, force },
+  });
+  return 'error';
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  if (!verifyCronAuth(request, ENDPOINT)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: RequestBody;
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+
+  const audiences = parseAudiences(body.audiences);
+  if (!audiences) {
+    return NextResponse.json(
+      { error: `audiences must be a non-empty subset of: ${VALID_AUDIENCES.join(', ')}` },
+      { status: 400 }
+    );
+  }
+
+  const from = process.env.REBRAND_FROM || DEFAULT_REBRAND_FROM;
+  const replyTo = process.env.REBRAND_REPLY_TO || DEFAULT_REBRAND_REPLY_TO;
+  if (!from || from.includes('onboarding@resend.dev')) {
+    return NextResponse.json(
+      { error: 'REBRAND_FROM is not configured with a verified sender address' },
+      { status: 500 }
+    );
+  }
+  if (!from.includes(EXPECTED_SENDER_DOMAIN)) {
+    return NextResponse.json(
+      {
+        error: `Rename email must send from the warmed ${EXPECTED_SENDER_DOMAIN} domain, not "${from}"`,
+      },
+      { status: 500 }
+    );
+  }
+
+  const postalAddress = process.env.COMPANY_POSTAL_ADDRESS;
+
+  const wantsDryRun = body.dryRun === true;
+  const wantsRealSend = body.confirm === true;
+  const wantsTest = body.testEmail !== undefined;
+
+  // Ambiguous intent: a broadcast AND a single test in one call would silently
+  // send only the test and skip the broadcast. Refuse so a stale testEmail left
+  // in a confirm payload can't be mistaken for a completed blast.
+  if (wantsRealSend && wantsTest) {
+    return NextResponse.json({ error: 'Pass either testEmail or confirm, not both.' }, { status: 400 });
+  }
+
+  // Dry run is the default AND a hard override: an explicit dryRun:true forces
+  // the count-only path even when confirm/testEmail are also set, so a stale
+  // confirm in a reused request body can never turn a preview into a live send.
+  // Counts render no mail, so they need neither the env guard nor the postal address.
+  if (wantsDryRun || (!wantsRealSend && !wantsTest)) {
+    const counts: Record<string, number> = {};
+    let total = 0;
+    for (const audience of audiences) {
+      const count = await getAudienceCount(audience);
+      counts[audience] = count;
+      total += count;
+    }
+    return NextResponse.json({ dryRun: true, audiences: counts, total });
+  }
+
+  // Every live send — a single test OR the full broadcast — is gated on the
+  // environment guard, so nothing can fire from CI, a preview, or a dev shell.
+  if (!realSendAllowed()) {
+    return NextResponse.json(
+      { error: 'Live send refused. Requires NODE_ENV=production and ALLOW_REAL_SEND=1.' },
+      { status: 403 }
+    );
+  }
+
+  // Any rendered email needs the CAN-SPAM postal address.
+  if (!postalAddress || !postalAddress.trim()) {
+    return NextResponse.json(
+      { error: 'COMPANY_POSTAL_ADDRESS must be set (CAN-SPAM requires a physical mailing address)' },
+      { status: 500 }
+    );
+  }
+
+  const getHtml = (params: { email: string; firstName?: string; unsubscribeUrl: string }) =>
+    getRebrandAnnouncementHtml({
+      firstName: params.firstName,
+      unsubscribeUrl: params.unsubscribeUrl,
+      postalAddress,
+    });
+
+  if (wantsTest) {
+    if (typeof body.testEmail !== 'string' || !body.testEmail.trim()) {
+      return NextResponse.json({ error: 'testEmail must be a non-empty string' }, { status: 400 });
+    }
+    const result = await sendBroadcast({
+      audience: audiences[0],
+      subject: REBRAND_ANNOUNCEMENT_SUBJECT,
+      from,
+      replyTo,
+      testEmail: body.testEmail,
+      getHtml,
+    });
+    return NextResponse.json({ testEmail: body.testEmail, sent: result.sent, failed: result.failed });
+  }
+
+  const supabase = createAdminClient();
+  const claim = await claimCampaignMarker(supabase, audiences, body.force === true);
+  if (claim === 'already-sent') {
+    return NextResponse.json(
+      {
+        error: `Campaign "${REBRAND_CAMPAIGN}" has already been sent. Inspect Resend first, then retry with force: true scoped to any failed audiences.`,
+      },
+      { status: 409 }
+    );
+  }
+  if (claim === 'error') {
+    return NextResponse.json({ error: 'Failed to record campaign marker' }, { status: 500 });
+  }
+
+  try {
+    const results: BroadcastResult[] = [];
+    const sentRecipients: SentRecipient[] = [];
+    const failedAudiences: AudienceId[] = [];
+
+    for (const audience of audiences) {
+      try {
+        const result = await sendBroadcast({
+          audience,
+          subject: REBRAND_ANNOUNCEMENT_SUBJECT,
+          from,
+          replyTo,
+          getHtml,
+        });
+        results.push({
+          audience: result.audience,
+          total: result.total,
+          sent: result.sent,
+          failed: result.failed,
+        });
+        sentRecipients.push(...result.sentRecipients);
+      } catch (audienceError) {
+        failedAudiences.push(audience);
+        loggerService.error('Rebrand announcement audience send failed', audienceError, {
+          category: LogCategory.EMAIL,
+          action: 'rebrand_email_audience_failed',
+          metadata: { campaign: REBRAND_CAMPAIGN, audience },
+        });
+      }
+    }
+
+    const totals = results.reduce(
+      (acc, r) => ({ total: acc.total + r.total, sent: acc.sent + r.sent, failed: acc.failed + r.failed }),
+      { total: 0, sent: 0, failed: 0 }
+    );
+
+    const { error: updateError } = await supabase
+      .from('campaign_sends')
+      .update({ recipient_count: totals.sent })
+      .eq('campaign', REBRAND_CAMPAIGN);
+    if (updateError) {
+      loggerService.error('Failed to persist rebrand recipient_count', updateError, {
+        category: LogCategory.EMAIL,
+        action: 'rebrand_email_marker_update_failed',
+        metadata: { campaign: REBRAND_CAMPAIGN, sent: totals.sent },
+      });
+    }
+
+    await captureServerEvent('rebrand_broadcast', 'email_broadcast_sent', {
+      campaign: REBRAND_CAMPAIGN,
+      dryRun: false,
+      ...totals,
+    });
+
+    loggerService.info('Rebrand announcement broadcast complete', {
+      category: LogCategory.BUSINESS,
+      action: 'rebrand_email_broadcast_complete',
+      metadata: { campaign: REBRAND_CAMPAIGN, ...totals },
+    });
+
+    return NextResponse.json({ audiences: results, failedAudiences, ...totals });
+  } catch (error) {
+    loggerService.error('Rebrand announcement broadcast failed', error, {
+      category: LogCategory.EMAIL,
+      action: 'rebrand_email_broadcast_failed',
+      metadata: { campaign: REBRAND_CAMPAIGN },
+    });
+    return NextResponse.json(
+      { error: 'Broadcast failed after the campaign marker was written. Inspect Resend before retrying with force: true.' },
+      { status: 500 }
+    );
+  }
+}

--- a/components/rebrand-banner.tsx
+++ b/components/rebrand-banner.tsx
@@ -98,7 +98,7 @@ export function RebrandBanner() {
           type="button"
           onClick={handleDismiss}
           aria-label="Dismiss announcement"
-          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md hover:bg-primary-foreground/10"
+          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md hover:bg-primary-foreground/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-primary"
         >
           <X className="h-5 w-5" aria-hidden="true" />
         </button>

--- a/components/rebrand-banner.tsx
+++ b/components/rebrand-banner.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { X } from "lucide-react";
+import { useSupabaseAuth } from "@/hooks/use-supabase-auth";
+import { capturePostHogEvent } from "@/lib/analytics/posthog";
+import { REBRAND_COPY } from "@/lib/constants/rebrand";
+
+const DISMISS_KEY = "ff:rebrand-banner-dismissed";
+
+// NEXT_PUBLIC_* env vars must be referenced as static literals for Next to
+// inline them into the client bundle — a dynamic process.env[key] lookup is
+// not replaced at build time and reads undefined in the browser.
+function bannerWindowOpen(): boolean {
+  return process.env.NEXT_PUBLIC_REBRAND_BANNER === "on";
+}
+
+/**
+ * Existing users (created before the rename cutover) see the banner; accounts
+ * created at/after the cutover are new and never do. Fail closed: if either the
+ * account timestamp or the cutover instant is missing/unparseable, treat the
+ * user as ineligible so the banner never shows to the wrong audience.
+ */
+function createdBeforeCutover(createdAt: string | undefined): boolean {
+  const cutoverRaw = process.env.NEXT_PUBLIC_REBRAND_CUTOVER_AT;
+  if (!createdAt || !cutoverRaw) return false;
+  const created = Date.parse(createdAt);
+  const cutover = Date.parse(cutoverRaw);
+  if (Number.isNaN(created) || Number.isNaN(cutover)) return false;
+  return created < cutover;
+}
+
+export function RebrandBanner() {
+  const { user, loading } = useSupabaseAuth();
+  // Assume dismissed until localStorage is read, so an already-dismissed banner
+  // never flashes on load.
+  const [dismissed, setDismissed] = useState(true);
+
+  useEffect(() => {
+    try {
+      setDismissed(localStorage.getItem(DISMISS_KEY) === "true");
+    } catch {
+      setDismissed(false);
+    }
+  }, []);
+
+  const visible =
+    !loading &&
+    !!user &&
+    bannerWindowOpen() &&
+    createdBeforeCutover(user.created_at) &&
+    !dismissed;
+
+  const handleDismiss = useCallback(() => {
+    setDismissed(true);
+    try {
+      localStorage.setItem(DISMISS_KEY, "true");
+    } catch {
+      // Per-device dismissal is best-effort; a storage failure just means the
+      // banner may reappear next load — never a crash or a blocked render.
+    }
+    capturePostHogEvent("rebrand_banner_dismissed");
+  }, []);
+
+  // Fire the impression at most once per mount, so a brief auth flicker can't
+  // inflate the shown count with duplicate events.
+  const shownFired = useRef(false);
+  useEffect(() => {
+    if (visible && !shownFired.current) {
+      shownFired.current = true;
+      capturePostHogEvent("rebrand_banner_shown");
+    }
+  }, [visible]);
+
+  useEffect(() => {
+    if (!visible) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") handleDismiss();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [visible, handleDismiss]);
+
+  if (!visible) return null;
+
+  return (
+    <div role="status" aria-live="polite" className="bg-primary text-primary-foreground">
+      <div className="container mx-auto flex items-center gap-4 px-4 py-3">
+        <p className="flex-1 text-sm sm:text-base">
+          <span className="font-semibold">{REBRAND_COPY.headline}</span>{" "}
+          <span className="opacity-90">{REBRAND_COPY.subhead}</span>{" "}
+          <Link href={REBRAND_COPY.whyHref} className="underline underline-offset-2">
+            {REBRAND_COPY.whyLabel}
+          </Link>
+        </p>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Dismiss announcement"
+          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md hover:bg-primary-foreground/10"
+        >
+          <X className="h-5 w-5" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/lib/constants/rebrand.ts
+++ b/lib/constants/rebrand.ts
@@ -1,0 +1,27 @@
+/**
+ * Single source of truth for AppTrack -> CareerOtter rename messaging.
+ *
+ * Imported by the in-app transition banner (`components/rebrand-banner.tsx`)
+ * and the rename-announcement email (`lib/email/templates/rebrand-announcement.ts`)
+ * so the two user-facing surfaces can never drift. The roast 301 redirect copy
+ * in `lib/rebrand-redirect.ts` should also import from here once M1 lands.
+ */
+export const REBRAND_COPY = {
+  headline: "AppTrack is now CareerOtter",
+  subhead: "Same account, same data, same login — only the name has changed.",
+  whyLabel: "Why the new name?",
+  /** Points at the (post-cutover, CareerOtter-branded) marketing home. */
+  whyHref: "/",
+} as const;
+
+/**
+ * `campaign_sends.campaign` marker id for the rename email — the primary-key
+ * guard that stops a re-trigger from double-sending the announcement.
+ */
+export const REBRAND_CAMPAIGN = "rebrand_announcement";
+
+// Banner visibility is controlled by two client-visible env vars, referenced as
+// static literals in rebrand-banner.tsx (Next only inlines literal NEXT_PUBLIC_*
+// reads into the client bundle, so they can't be indirected through a constant):
+//   NEXT_PUBLIC_REBRAND_BANNER     — "on" during the bounded post-cutover window
+//   NEXT_PUBLIC_REBRAND_CUTOVER_AT — ISO instant separating existing vs new users

--- a/lib/email/templates/rebrand-announcement.ts
+++ b/lib/email/templates/rebrand-announcement.ts
@@ -1,0 +1,56 @@
+/**
+ * AppTrack -> CareerOtter rename announcement email.
+ *
+ * Sent once, owner-triggered, via POST /api/admin/rebrand-email. Copy comes from
+ * the shared `REBRAND_COPY` constant so it can't drift from the in-app banner.
+ *
+ * Sender: the WARMED apptrack.ing domain, NOT the fresh careerotter.io —
+ * announcing a domain change from a cold sending domain wrecks deliverability.
+ */
+
+import { REBRAND_COPY } from '@/lib/constants/rebrand';
+import { escapeHtml, EMAIL_THEME, wrapEmail } from './shared';
+
+export const REBRAND_ANNOUNCEMENT_SUBJECT = REBRAND_COPY.headline;
+
+export const DEFAULT_REBRAND_FROM = 'Jordan at AppTrack <jordan@apptrack.ing>';
+export const DEFAULT_REBRAND_REPLY_TO = 'jordan@apptrack.ing';
+
+export type RebrandAnnouncementParams = {
+  firstName?: string;
+  unsubscribeUrl: string;
+  /** CAN-SPAM: a valid physical postal address, rendered in the footer. */
+  postalAddress: string;
+};
+
+export function getRebrandAnnouncementHtml(params: RebrandAnnouncementParams): string {
+  const greeting = params.firstName ? `Hi ${escapeHtml(params.firstName)},` : 'Hi there,';
+
+  const content = `
+    <p style="margin: 0 0 16px; font-size: 16px; color: ${EMAIL_THEME.heading};">
+      ${greeting}
+    </p>
+    <p style="margin: 0 0 16px; font-size: 16px; color: ${EMAIL_THEME.body};">
+      Quick heads-up: <strong>${escapeHtml(REBRAND_COPY.headline)}</strong>
+    </p>
+    <p style="margin: 0 0 16px; font-size: 16px; color: ${EMAIL_THEME.body};">
+      ${escapeHtml(REBRAND_COPY.subhead)} Your account, your data, and how you log in all
+      stay exactly the same — you don't need to do anything.
+    </p>
+    <p style="margin: 0 0 8px; font-size: 16px; color: ${EMAIL_THEME.body};">
+      One thing to note: our emails will start arriving from a careerotter.io address, so
+      if you filter or star messages from us, you may want to update that.
+    </p>
+    <p style="margin: 24px 0 0; font-size: 14px; color: ${EMAIL_THEME.muted};">
+      Questions? Just reply — I read every one.
+    </p>`;
+
+  // footerNote carries the CAN-SPAM postal address alongside wrapEmail's
+  // unsubscribe link (kept because this is a commercial broadcast).
+  return wrapEmail(content, {
+    unsubscribeUrl: params.unsubscribeUrl,
+    footerNote: `You're receiving this because you have a CareerOtter (formerly AppTrack) account. ${escapeHtml(
+      params.postalAddress
+    )}`,
+  });
+}

--- a/lib/hooks/use-feature-flag.ts
+++ b/lib/hooks/use-feature-flag.ts
@@ -21,6 +21,11 @@ export const FEATURE_FLAGS = {
   ONBOARDING_V2: "onboarding-v2",
   ENHANCED_ANALYTICS: "enhanced-analytics",
   SHOW_TESTIMONIALS: "show-testimonials",
+
+  // CareerOtter Phase 2 — single switch gating the net-new evidence-loop
+  // surfaces (M2b wins UI, M3 coach, M4 case builder, M5 comp, M7 nav entries).
+  // Default OFF everywhere; wired into surfaces per-PR as they merge.
+  CAREEROTTER_EVIDENCE: "careerotter-evidence",
 } as const;
 
 export type FeatureFlag = typeof FEATURE_FLAGS[keyof typeof FEATURE_FLAGS];


### PR DESCRIPTION
Launch-readiness kit for the AppTrack → CareerOtter cutover. Ships the mechanism; the actual launch (domain, flag ramp, email send) stays owner-gated.

## What's here
- **Transition banner** (`components/rebrand-banner.tsx`, mounted in the app shell) — dismissible "AppTrack is now CareerOtter" for existing users only, gated on `NEXT_PUBLIC_REBRAND_BANNER` + account age; default off; PostHog shown/dismissed events.
- **Rename email** (`app/api/admin/rebrand-email/route.ts` + template) — owner-triggered broadcast, **dry-run by default**, real send needs `NODE_ENV=production` AND `ALLOW_REAL_SEND=1` AND `confirm:true`; sent from the warmed apptrack.ing domain; CAN-SPAM footer; campaign-marker idempotency. Mirrors the proven `career-validation-email` route.
- **`careerotter_evidence` flag primitive** — added to `FEATURE_FLAGS`, default OFF (client + server). Wired into surfaces per-PR as M2b–M5 merge.
- **Shared copy source** (`lib/constants/rebrand.ts`) so banner + email can't drift.
- **Launch docs** — PRD, rollout plan, stamped go/no-go checklist (`.claude/ship/`).

## Tests
24 new tests (banner render matrix, email send-safety contract, flag default-off). Full suite: 103 suites / 1489 pass.

## Not in scope (owner-gated)
Merging the 10 PRs, domain/DNS cutover, flipping the flag to 100%, sending the real email.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an AppTrack-to-CareerOtter rebrand banner for eligible signed-in users, with accessible messaging, analytics, and dismissal support.
  - Added a rebrand announcement email template and protected admin sending workflow with previews, safeguards, unsubscribe support, and duplicate-send prevention.
  - Added a default-off feature flag for upcoming evidence-related product surfaces.

- **Documentation**
  - Added launch-readiness, rollout, and go/no-go documentation covering rebrand deployment, feature-flag ramping, verification, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->