### PR TITLE
Gate CareerOtter Phase 2 surfaces behind launch switch (hotfix)

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,40 @@
 import { createServerClient } from "@supabase/ssr"
 import { NextResponse, type NextRequest } from "next/server"
 
+// CareerOtter Phase 2 surfaces (merged to main ahead of launch) stay hidden
+// until the launch switch is flipped. Matched with segment boundaries so a route
+// like /dashboard/companies could never be caught by /dashboard/comp.
+function isCareerotterSurface(pathname: string): boolean {
+  const pageRoutes = [
+    "/dashboard/start", // Zero-to-Case onboarding
+    "/dashboard/wins",
+    "/dashboard/coach",
+    "/dashboard/comp",
+    "/dashboard/data", // privacy/data page
+    "/dashboard/review-prep",
+  ]
+  if (pageRoutes.some((r) => pathname === r || pathname.startsWith(r + "/"))) {
+    return true
+  }
+  return (
+    pathname.startsWith("/api/careerotter/") ||
+    pathname.startsWith("/api/wins/") ||
+    pathname === "/api/wins" ||
+    pathname === "/api/cron/careerotter-recap"
+  )
+}
+
 export async function middleware(request: NextRequest) {
+  // Hard launch gate, evaluated before anything else: 404 the not-yet-launched
+  // CareerOtter routes unless CAREEROTTER_ENABLED=1. Keeps them unreachable in
+  // production while their code sits merged-but-dark on main.
+  if (
+    process.env.CAREEROTTER_ENABLED !== "1" &&
+    isCareerotterSurface(request.nextUrl.pathname)
+  ) {
+    return new NextResponse("Not Found", { status: 404 })
+  }
+
   const hostname = request.headers.get("host") || ""
 
   // Redirect non-www to www for canonical URL consistency
@@ -75,5 +108,10 @@ export const config = {
      * - api routes (handled separately)
      */
     "/((?!_next/static|_next/image|favicon.ico|api/).*)",
+    // CareerOtter API + cron surfaces are excluded by the pattern above (api/),
+    // so match them explicitly for the launch gate.
+    "/api/careerotter/:path*",
+    "/api/wins/:path*",
+    "/api/cron/careerotter-recap",
   ],
 }


### PR DESCRIPTION
Merged milestones don't check the flag; middleware hard-gate 404s all CareerOtter routes unless CAREEROTTER_ENABLED=1. Default off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a launch gate for CareerOtter pages and related API and scheduled-task routes.
  * Disabled CareerOtter routes now return a not-found response until the feature is enabled.
  * Added coverage for CareerOtter and wins API paths in request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->