### PR TITLE
Remove the career waitlist banner (CareerOtter is live)

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -9,7 +9,6 @@ import { DashboardSuccessToast } from "@/components/dashboard-success-toast";
 import { Toaster } from "@/components/ui/toaster";
 import { DashboardWithOnboarding } from "@/components/dashboard-with-onboarding";
 import { HiredSubscriptionBanner } from "@/components/hired-subscription-banner";
-import { CareerWaitlistBanner } from "@/components/career-waitlist-banner";
 import { isOnProOrHigher } from "@/lib/utils/plan-helpers";
 import { TodayOverview } from "@/components/careerotter/today-overview";
 
@@ -82,19 +81,12 @@ export default async function DashboardPage() {
                 (a) => a.status === "Hired"
               );
               const isPaidSubscriber = isOnProOrHigher(planName || "Free");
-              const hiredBannerEligible = hasHiredApplication && isPaidSubscriber;
               return (
-                <>
-                  <HiredSubscriptionBanner
-                    hasHiredApplication={hasHiredApplication}
-                    isPaidSubscriber={isPaidSubscriber}
-                    userId={user.id}
-                  />
-                  <CareerWaitlistBanner
-                    userId={user.id}
-                    hiredBannerEligible={hiredBannerEligible}
-                  />
-                </>
+                <HiredSubscriptionBanner
+                  hasHiredApplication={hasHiredApplication}
+                  isPaidSubscriber={isPaidSubscriber}
+                  userId={user.id}
+                />
               );
             })()}
 


### PR DESCRIPTION
The "Planning your next raise? … Join the waitlist" banner on the logged-in dashboard was Phase 0 demand validation — obsolete now that the product has shipped. Removes it plus the now-unused import and `hiredBannerEligible`. `HiredSubscriptionBanner` is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the career waitlist banner from the dashboard.
  * Simplified the dashboard banner display to show only the hired subscription banner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->