### PR TITLE
Comp: Finnhub price polling — live equity value (Phase 2)

### DIFF
--- a/app/api/careerotter/comp/route.ts
+++ b/app/api/careerotter/comp/route.ts
@@ -43,10 +43,31 @@ export async function GET(request: NextRequest) {
   // Benchmark is Pro-only; entry/history is free.
   const marketRange = plan.isPro ? lookupMarketRange(roleFamily, level) : null;
 
+  // Live cached prices for the tickers this user tracks (feature is dark until the
+  // polling cron populates stock_prices; absent tickers simply won't appear).
+  const tickers = [
+    ...new Set(
+      (entries ?? [])
+        .map((e) => (typeof e.ticker === "string" ? e.ticker.trim() : ""))
+        .filter((t) => t.length > 0)
+    ),
+  ];
+  const prices: Record<string, { price: number; as_of: string }> = {};
+  if (tickers.length > 0) {
+    const { data: priceRows } = await admin
+      .from("stock_prices")
+      .select("ticker, price, as_of")
+      .in("ticker", tickers);
+    for (const row of priceRows ?? []) {
+      prices[row.ticker] = { price: Number(row.price), as_of: row.as_of };
+    }
+  }
+
   return NextResponse.json({
     entries: entries ?? [],
     marketRange,
     isPro: plan.isPro,
+    prices,
   });
 }
 

--- a/app/api/cron/careerotter-stock-prices/route.ts
+++ b/app/api/cron/careerotter-stock-prices/route.ts
@@ -1,0 +1,110 @@
+/**
+ * Stock price polling cron (CareerOtter Phase 2, comp equity).
+ *
+ * Daily job: collect the distinct public tickers referenced by comp_entries,
+ * fetch each one's current price from Finnhub, and cache it in stock_prices so
+ * the equity scenario slider can anchor on the live market price.
+ *
+ * The feature is DARK until FINNHUB_API_KEY is set: with no key this route
+ * no-ops cleanly (skipped response, no DB work, no external calls).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { verifyCronAuth } from "@/lib/email/lifecycle-cron";
+import { createAdminClient } from "@/lib/supabase/admin-client";
+import { fetchQuote, isPriceFeedConfigured } from "@/lib/careerotter/stock-price";
+import { loggerService } from "@/lib/services/logger.service";
+import { LogCategory } from "@/lib/services/logger.types";
+
+export const maxDuration = 300;
+
+const ENDPOINT = "/api/cron/careerotter-stock-prices";
+const MAX_TICKERS = 100; // Backstop for a runaway job; log if we hit it.
+const CALL_DELAY_MS = 250; // Respect the Finnhub free-tier rate limit.
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  if (!verifyCronAuth(request, ENDPOINT)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!isPriceFeedConfigured()) {
+    return NextResponse.json({ skipped: "no FINNHUB_API_KEY" });
+  }
+
+  const admin = createAdminClient();
+
+  const { data: rows, error } = await admin
+    .from("comp_entries")
+    .select("ticker")
+    .not("ticker", "is", null);
+
+  if (error) {
+    loggerService.error("Stock price cron: failed to load tickers", error, {
+      category: LogCategory.BUSINESS,
+      action: "careerotter_stock_prices_query_failed",
+    });
+    return NextResponse.json({ error: "query failed" }, { status: 500 });
+  }
+
+  // Dedupe non-empty tickers in code (the table stores per-entry rows).
+  const tickers = [
+    ...new Set(
+      (rows ?? [])
+        .map((r) => (typeof r.ticker === "string" ? r.ticker.trim() : ""))
+        .filter((t) => t.length > 0)
+    ),
+  ];
+
+  const capped = tickers.length > MAX_TICKERS;
+  const toProcess = tickers.slice(0, MAX_TICKERS);
+  if (capped) {
+    loggerService.warn("Stock price cron: ticker count exceeded cap; some skipped", {
+      category: LogCategory.BUSINESS,
+      action: "careerotter_stock_prices_capped",
+      metadata: { total: tickers.length, cap: MAX_TICKERS },
+    });
+  }
+
+  let updated = 0;
+  let missed = 0;
+  for (let i = 0; i < toProcess.length; i++) {
+    const ticker = toProcess[i];
+    const price = await fetchQuote(ticker);
+    if (price !== null) {
+      const { error: upsertError } = await admin.from("stock_prices").upsert(
+        { ticker, price, as_of: new Date().toISOString() },
+        { onConflict: "ticker" }
+      );
+      if (upsertError) {
+        missed += 1;
+        loggerService.error("Stock price cron: upsert failed", upsertError, {
+          category: LogCategory.DATABASE,
+          action: "careerotter_stock_prices_upsert_failed",
+          metadata: { ticker },
+        });
+      } else {
+        updated += 1;
+      }
+    } else {
+      missed += 1;
+    }
+
+    // Throttle between calls (skip after the last one).
+    if (i < toProcess.length - 1) await sleep(CALL_DELAY_MS);
+  }
+
+  loggerService.info("Stock price cron complete", {
+    category: LogCategory.BUSINESS,
+    action: "careerotter_stock_prices_complete",
+    metadata: { tickers: tickers.length, processed: toProcess.length, updated, missed },
+  });
+
+  return NextResponse.json({
+    tickers: tickers.length,
+    processed: toProcess.length,
+    updated,
+    missed,
+  });
+}

--- a/components/careerotter/comp-tracker.tsx
+++ b/components/careerotter/comp-tracker.tsx
@@ -60,6 +60,9 @@ export function CompTracker() {
   const [entries, setEntries] = useState<CompEntry[]>([]);
   const [marketRange, setMarketRange] = useState<MarketRange | null>(null);
   const [isPro, setIsPro] = useState(false);
+  const [prices, setPrices] = useState<
+    Record<string, { price: number; as_of: string }>
+  >({});
   const [roleTitle, setRoleTitle] = useState("");
   const [level, setLevel] = useState("");
   const [form, setForm] = useState({
@@ -86,6 +89,7 @@ export function CompTracker() {
         setEntries(data.entries);
         setMarketRange(data.marketRange);
         setIsPro(data.isPro);
+        setPrices(data.prices ?? {});
       }
     } catch (err) {
       // A superseded or unmounted lookup aborts; ignore it. Other network errors
@@ -160,9 +164,16 @@ export function CompTracker() {
   const latestShares = latest?.shares ? Number(latest.shares) : 0;
   const hasShares = latestShares > 0;
   const latestEquity = latest ? Number(latest.equity) : 0;
-  // Anchor at the implied per-share price the recorded equity reflects, else $100.
-  const anchorPrice =
-    hasShares && latestEquity > 0 ? latestEquity / latestShares : 100;
+  // Prefer the live cached market price for the latest entry's ticker as the
+  // slider anchor; fall back to the implied per-share price the recorded equity
+  // reflects, else $100.
+  const livePrice =
+    latest?.ticker && prices[latest.ticker] ? prices[latest.ticker] : null;
+  const anchorPrice = livePrice
+    ? livePrice.price
+    : hasShares && latestEquity > 0
+      ? latestEquity / latestShares
+      : 100;
   const scenarioMax = Math.max(anchorPrice * 3, 1);
   const price = scenarioPrice ?? anchorPrice;
   const scenarioTotal = latest
@@ -283,6 +294,16 @@ export function CompTracker() {
                   }}
                   className="min-h-[44px] w-32"
                 />
+                {livePrice && (
+                  <p className="text-xs text-muted-foreground">
+                    {latest.ticker} as of{" "}
+                    {new Date(livePrice.as_of).toLocaleDateString("en-US", {
+                      year: "numeric",
+                      month: "short",
+                      day: "numeric",
+                    })}
+                  </p>
+                )}
               </div>
             </div>
 

--- a/lib/careerotter/stock-price.ts
+++ b/lib/careerotter/stock-price.ts
@@ -1,0 +1,40 @@
+/**
+ * Finnhub price feed (CareerOtter comp equity, Phase 2).
+ *
+ * The whole feature is DARK until FINNHUB_API_KEY is set: with no key, both the
+ * polling cron and any lookup no-op cleanly (fetchQuote returns null,
+ * isPriceFeedConfigured returns false). Public tickers only.
+ */
+
+const FINNHUB_QUOTE_URL = "https://finnhub.io/api/v1/quote";
+const QUOTE_TIMEOUT_MS = 8000;
+
+/** Whether the live price feed is enabled (an API key is configured). */
+export function isPriceFeedConfigured(): boolean {
+  return !!process.env.FINNHUB_API_KEY;
+}
+
+/**
+ * Fetch the current price for a public ticker from Finnhub.
+ * Returns the current price only when it is a finite number > 0, else null.
+ * Never throws: any missing key, network error, timeout, or bad payload → null.
+ */
+export async function fetchQuote(ticker: string): Promise<number | null> {
+  const token = process.env.FINNHUB_API_KEY;
+  if (!token) return null;
+
+  try {
+    const url = `${FINNHUB_QUOTE_URL}?symbol=${encodeURIComponent(ticker)}&token=${encodeURIComponent(token)}`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(QUOTE_TIMEOUT_MS) });
+    if (!res.ok) return null;
+
+    const data = (await res.json()) as { c?: unknown };
+    const price = data?.c;
+    if (typeof price === "number" && Number.isFinite(price) && price > 0) {
+      return price;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/schemas/migrations/036_stock_prices.sql
+++ b/schemas/migrations/036_stock_prices.sql
@@ -1,0 +1,16 @@
+-- 036_stock_prices.sql
+-- Cached live stock prices for the CareerOtter comp equity feature (Phase 2).
+-- A daily cron polls Finnhub for the tickers referenced by comp_entries and
+-- upserts the latest price here, so the equity scenario slider can anchor on the
+-- real market price instead of the implied per-share price. Public tickers only.
+-- Service-role only (written/read by API routes); no RLS policies are defined.
+
+create table if not exists public.stock_prices (
+  ticker text primary key,
+  price numeric(14,4) not null,
+  currency text not null default 'USD',
+  as_of timestamptz not null default now()
+);
+
+alter table public.stock_prices enable row level security;
+-- service-role only (API routes), no policies.

--- a/vercel.json
+++ b/vercel.json
@@ -27,6 +27,10 @@
     {
       "path": "/api/cron/careerotter-recap",
       "schedule": "0 22 * * 5"
+    },
+    {
+      "path": "/api/cron/careerotter-stock-prices",
+      "schedule": "0 6 * * *"
     }
   ]
 }


### PR DESCRIPTION
Daily cron polls Finnhub for the distinct tickers in comp_entries and caches them in a new `stock_prices` table; the comp GET returns a per-ticker price map, and the scenario slider anchors on the live price (falls back to manual). **Dark until `FINNHUB_API_KEY` is set** — no key → cron/lookups no-op. Migration 036 already applied to prod. Public tickers only; private companies keep manual entry.