### PR TITLE
feat(comp): delete comp entries

### DIFF
--- a/app/api/careerotter/comp/[id]/route.ts
+++ b/app/api/careerotter/comp/[id]/route.ts
@@ -1,0 +1,55 @@
+/**
+ * Comp tracker — delete a single entry (CareerOtter Phase 2, M5).
+ *
+ * DELETE /api/careerotter/comp/:id   remove a comp entry
+ *
+ * Scoped to the session user_id, so the service-role admin client (comp_entries
+ * is RLS service-role-only) can only ever touch the caller's own rows.
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin-client";
+import { loggerService } from "@/lib/services/logger.service";
+import { LogCategory } from "@/lib/services/logger.types";
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("comp_entries")
+    .delete()
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .select("id")
+    .maybeSingle();
+
+  if (error) {
+    loggerService.error("Failed to delete comp entry", error, {
+      category: LogCategory.DATABASE,
+      userId: user.id,
+      action: "comp_entry_delete_failed",
+    });
+    return NextResponse.json(
+      { error: "Failed to delete comp entry" },
+      { status: 500 }
+    );
+  }
+  if (!data) {
+    // No row matched: wrong id or not the caller's entry.
+    return NextResponse.json({ error: "Comp entry not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/components/careerotter/comp-tracker.tsx
+++ b/components/careerotter/comp-tracker.tsx
@@ -162,6 +162,10 @@ export function CompTracker() {
   }
 
   async function deleteEntry(id: string) {
+    // One delete at a time: the controls are disabled while a delete is in flight,
+    // but guard here too so a stray call can't start an overlapping request that
+    // would 404 once the row is already gone.
+    if (deletingId) return;
     setDeletingId(id);
     setError("");
     try {
@@ -439,7 +443,7 @@ export function CompTracker() {
                         type="button"
                         variant="ghost"
                         onClick={() => deleteEntry(e.id)}
-                        disabled={deletingId === e.id}
+                        disabled={deletingId !== null}
                         aria-label={`Confirm delete comp entry from ${e.effective_date}`}
                         className="h-11 px-3 text-destructive hover:text-destructive"
                       >
@@ -449,7 +453,7 @@ export function CompTracker() {
                         type="button"
                         variant="ghost"
                         onClick={() => setConfirmId(null)}
-                        disabled={deletingId === e.id}
+                        disabled={deletingId !== null}
                         aria-label="Cancel delete"
                         className="h-11 px-3 text-muted-foreground"
                       >
@@ -462,6 +466,7 @@ export function CompTracker() {
                       variant="ghost"
                       size="icon"
                       onClick={() => setConfirmId(e.id)}
+                      disabled={deletingId !== null}
                       aria-label={`Delete comp entry from ${e.effective_date}`}
                       className="h-11 w-11 text-muted-foreground hover:text-destructive"
                     >

--- a/components/careerotter/comp-tracker.tsx
+++ b/components/careerotter/comp-tracker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -76,6 +77,10 @@ export function CompTracker() {
   const [error, setError] = useState("");
   const [saving, setSaving] = useState(false);
   const [scenarioPrice, setScenarioPrice] = useState<number | null>(null);
+  // Two-step delete: first click arms confirmId, second confirms. Avoids a modal
+  // dependency while still guarding against an accidental permanent delete.
+  const [confirmId, setConfirmId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
 
   const load = useCallback(async (signal?: AbortSignal) => {
     const roleFamily = resolveRoleFamily(roleTitle);
@@ -153,6 +158,25 @@ export function CompTracker() {
       }
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function deleteEntry(id: string) {
+    setDeletingId(id);
+    setError("");
+    try {
+      const res = await fetch(`/api/careerotter/comp/${id}`, { method: "DELETE" });
+      if (res.ok) {
+        setEntries((prev) => prev.filter((entry) => entry.id !== id));
+      } else {
+        const data = await res.json().catch(() => null);
+        setError(data?.error || "Could not delete that entry.");
+      }
+    } catch {
+      setError("Could not delete that entry.");
+    } finally {
+      setDeletingId(null);
+      setConfirmId(null);
     }
   }
 
@@ -405,9 +429,46 @@ export function CompTracker() {
           <h3 className="text-sm font-semibold">Your trajectory</h3>
           <ul className="space-y-1">
             {[...entries].reverse().map((e) => (
-              <li key={e.id} className="flex items-center justify-between border-b py-2 text-sm">
+              <li key={e.id} className="flex items-center justify-between gap-2 border-b py-2 text-sm">
                 <span className="text-muted-foreground">{e.effective_date}</span>
-                <span className="tabular-nums font-medium">{usd(total(e))}</span>
+                <div className="flex items-center gap-2">
+                  <span className="tabular-nums font-medium">{usd(total(e))}</span>
+                  {confirmId === e.id ? (
+                    <>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={() => deleteEntry(e.id)}
+                        disabled={deletingId === e.id}
+                        aria-label={`Confirm delete comp entry from ${e.effective_date}`}
+                        className="h-11 px-3 text-destructive hover:text-destructive"
+                      >
+                        {deletingId === e.id ? "Deleting…" : "Delete"}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={() => setConfirmId(null)}
+                        disabled={deletingId === e.id}
+                        aria-label="Cancel delete"
+                        className="h-11 px-3 text-muted-foreground"
+                      >
+                        Cancel
+                      </Button>
+                    </>
+                  ) : (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => setConfirmId(e.id)}
+                      aria-label={`Delete comp entry from ${e.effective_date}`}
+                      className="h-11 w-11 text-muted-foreground hover:text-destructive"
+                    >
+                      <Trash2 className="h-4 w-4" aria-hidden="true" />
+                    </Button>
+                  )}
+                </div>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Why
Found during the production smoke test: comp entries were **add-only** — no delete/edit UI and the comp route had no DELETE, so a fat-fingered entry couldn't be removed.

## What
- **DELETE `/api/careerotter/comp/:id`** — scoped to the session `user_id` (service-role admin client), 404 if not the caller's row. Mirrors the wins `[id]` DELETE.
- **Two-step inline delete** in the "Your trajectory" list: trash icon → Delete / Cancel. No modal dependency, 44px touch targets, optimistic removal.

Edit is still not offered (delete unblocks the practical problem); can follow up if wanted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to delete compensation history entries.
  * Deletion requires a confirmation click to help prevent accidental removal.
  * Added loading feedback while an entry is being deleted.
  * Entries are removed from the history only after deletion succeeds.
  * Added clear error messaging when deletion cannot be completed.
  * Unauthorized or unavailable entries cannot be deleted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->