### PR TITLE
perf(dashboard): dedupe redundant profile/onboarding fetches

### DIFF
--- a/hooks/use-onboarding-trigger.ts
+++ b/hooks/use-onboarding-trigger.ts
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { useSupabaseAuthSimple } from '@/hooks/use-supabase-auth-simple'
 import { useOnboarding } from '@/lib/onboarding/context'
+import { dedupedGetJson } from '@/lib/utils/deduped-get'
 
 export function useOnboardingTrigger() {
   const { user } = useSupabaseAuthSimple()
@@ -14,18 +15,20 @@ export function useOnboardingTrigger() {
 
     const checkUserStatus = async () => {
       try {
-        // Call API route to check onboarding status
-        const response = await fetch('/api/onboarding/status')
-        
-        if (!response.ok) {
+        // Call API route to check onboarding status. Deduped because this effect
+        // re-runs as the auth `user` reference settles, firing several times per
+        // load. See lib/utils/deduped-get.
+        const { ok, body } = await dedupedGetJson('/api/onboarding/status')
+
+        if (!ok) {
           console.error('Failed to check onboarding status')
           return
         }
-        
-        const data = await response.json()
-        
+
+        const data = (body ?? {}) as { shouldStartOnboarding?: boolean }
+
         console.log('Onboarding check:', data)
-        
+
         if (data.shouldStartOnboarding) {
           console.log('Starting onboarding flow...')
           await startFlow('new-user-onboarding')

--- a/hooks/use-supabase-auth-simple.ts
+++ b/hooks/use-supabase-auth-simple.ts
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import type { User } from "@supabase/supabase-js";
 import { supabase } from "@/lib/supabase";
 import type { Profile } from "@/lib/supabase";
-import { dedupedGetJson, invalidateGet } from "@/lib/utils/deduped-get";
+import { dedupedGetJson, clearGetCache } from "@/lib/utils/deduped-get";
 
 export function useSupabaseAuthSimple() {
   const [user, setUser] = useState<User | null>(null);
@@ -41,8 +41,9 @@ export function useSupabaseAuthSimple() {
       if (session?.user) {
         await fetchProfile(session.user.id);
       } else {
-        // Signed out: drop the cached profile so a later sign-in refetches fresh.
-        invalidateGet("/api/auth/profile");
+        // Signed out: wipe the shared GET cache so a different user signing in
+        // next can't be served this user's cached profile/onboarding data.
+        clearGetCache();
         setProfile(null);
       }
 

--- a/hooks/use-supabase-auth-simple.ts
+++ b/hooks/use-supabase-auth-simple.ts
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import type { User } from "@supabase/supabase-js";
 import { supabase } from "@/lib/supabase";
 import type { Profile } from "@/lib/supabase";
+import { dedupedGetJson, invalidateGet } from "@/lib/utils/deduped-get";
 
 export function useSupabaseAuthSimple() {
   const [user, setUser] = useState<User | null>(null);
@@ -40,6 +41,8 @@ export function useSupabaseAuthSimple() {
       if (session?.user) {
         await fetchProfile(session.user.id);
       } else {
+        // Signed out: drop the cached profile so a later sign-in refetches fresh.
+        invalidateGet("/api/auth/profile");
         setProfile(null);
       }
 
@@ -51,20 +54,12 @@ export function useSupabaseAuthSimple() {
 
   const fetchProfile = async (userId: string) => {
     try {
-      const response = await fetch("/api/auth/profile", {
-        method: "GET",
-        credentials: "include",
-      });
-
-      if (!response.ok) {
-        if (response.status === 404) {
-          // Profile not found, which is okay
-          return;
-        }
-        return;
-      }
-
-      const { profile } = await response.json();
+      // Deduped: many components mount this hook and Supabase fires an initial
+      // auth event, so the raw fetch ran several times per load. See deduped-get.
+      const { ok, body } = await dedupedGetJson("/api/auth/profile");
+      // Any non-ok (incl. 404 "profile not found") is fine — just don't set it.
+      if (!ok) return;
+      const profile = (body as { profile?: Profile } | null)?.profile;
       if (profile) {
         setProfile(profile);
       }

--- a/hooks/use-supabase-auth-simple.ts
+++ b/hooks/use-supabase-auth-simple.ts
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import type { User } from "@supabase/supabase-js";
 import { supabase } from "@/lib/supabase";
 import type { Profile } from "@/lib/supabase";
-import { dedupedGetJson, clearGetCache } from "@/lib/utils/deduped-get";
+import { dedupedGetJson, clearGetCache, getGetCacheEpoch } from "@/lib/utils/deduped-get";
 
 export function useSupabaseAuthSimple() {
   const [user, setUser] = useState<User | null>(null);
@@ -57,7 +57,11 @@ export function useSupabaseAuthSimple() {
     try {
       // Deduped: many components mount this hook and Supabase fires an initial
       // auth event, so the raw fetch ran several times per load. See deduped-get.
+      const startEpoch = getGetCacheEpoch();
       const { ok, body } = await dedupedGetJson("/api/auth/profile");
+      // Auth turned over while this was in flight (sign-out, or a different user
+      // signed in): the response belongs to the previous session — ignore it.
+      if (getGetCacheEpoch() !== startEpoch) return;
       // Any non-ok (incl. 404 "profile not found") is fine — just don't set it.
       if (!ok) return;
       const profile = (body as { profile?: Profile } | null)?.profile;

--- a/hooks/use-supabase-auth.ts
+++ b/hooks/use-supabase-auth.ts
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import type { User } from "@supabase/supabase-js";
 import { supabase } from "@/lib/supabase";
 import type { Profile } from "@/lib/supabase";
-import { dedupedGetJson, clearGetCache } from "@/lib/utils/deduped-get";
+import { dedupedGetJson, clearGetCache, getGetCacheEpoch } from "@/lib/utils/deduped-get";
 
 export function useSupabaseAuth() {
   const [user, setUser] = useState<User | null>(null);
@@ -57,7 +57,13 @@ export function useSupabaseAuth() {
     try {
       // Deduped: many components mount this hook and Supabase fires an initial
       // auth event, so the raw fetch ran several times per load. See deduped-get.
+      const startEpoch = getGetCacheEpoch();
       const { ok, body } = await dedupedGetJson("/api/auth/profile");
+      // Auth turned over while this was in flight (sign-out, or a different user
+      // signed in): the response belongs to the previous session — ignore it.
+      if (getGetCacheEpoch() !== startEpoch) {
+        return;
+      }
       if (!ok) {
         return;
       }

--- a/hooks/use-supabase-auth.ts
+++ b/hooks/use-supabase-auth.ts
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import type { User } from "@supabase/supabase-js";
 import { supabase } from "@/lib/supabase";
 import type { Profile } from "@/lib/supabase";
-import { dedupedGetJson, invalidateGet } from "@/lib/utils/deduped-get";
+import { dedupedGetJson, clearGetCache } from "@/lib/utils/deduped-get";
 
 export function useSupabaseAuth() {
   const [user, setUser] = useState<User | null>(null);
@@ -41,8 +41,9 @@ export function useSupabaseAuth() {
       if (session?.user) {
         await fetchProfile(session.user.id);
       } else {
-        // Signed out: drop the cached profile so a later sign-in refetches fresh.
-        invalidateGet("/api/auth/profile");
+        // Signed out: wipe the shared GET cache so a different user signing in
+        // next can't be served this user's cached profile/onboarding data.
+        clearGetCache();
         setProfile(null);
       }
 

--- a/hooks/use-supabase-auth.ts
+++ b/hooks/use-supabase-auth.ts
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import type { User } from "@supabase/supabase-js";
 import { supabase } from "@/lib/supabase";
 import type { Profile } from "@/lib/supabase";
+import { dedupedGetJson, invalidateGet } from "@/lib/utils/deduped-get";
 
 export function useSupabaseAuth() {
   const [user, setUser] = useState<User | null>(null);
@@ -40,6 +41,8 @@ export function useSupabaseAuth() {
       if (session?.user) {
         await fetchProfile(session.user.id);
       } else {
+        // Signed out: drop the cached profile so a later sign-in refetches fresh.
+        invalidateGet("/api/auth/profile");
         setProfile(null);
       }
 
@@ -51,17 +54,15 @@ export function useSupabaseAuth() {
 
   const fetchProfile = async (userId: string) => {
     try {
-      const response = await fetch("/api/auth/profile", {
-        method: "GET",
-        credentials: "include",
-      });
-
-      if (!response.ok) {
+      // Deduped: many components mount this hook and Supabase fires an initial
+      // auth event, so the raw fetch ran several times per load. See deduped-get.
+      const { ok, body } = await dedupedGetJson("/api/auth/profile");
+      if (!ok) {
         return;
       }
 
-      const { profile } = await response.json();
-      
+      const profile = (body as { profile?: Profile } | null)?.profile;
+
       if (!profile) {
         return;
       }

--- a/lib/utils/deduped-get.ts
+++ b/lib/utils/deduped-get.ts
@@ -42,9 +42,12 @@ export async function dedupedGetJson(
   inFlight.set(url, request);
   try {
     const value = await request;
-    // Only successful reads are cached; a thrown request leaves no entry so the
-    // next caller retries.
-    cache.set(url, { at: Date.now(), value });
+    // Cache only successful reads. A 4xx/5xx (value.ok === false) or a thrown
+    // request leaves no entry, so the next caller retries instead of being pinned
+    // to a failure for the whole TTL.
+    if (value.ok) {
+      cache.set(url, { at: Date.now(), value });
+    }
     return value;
   } finally {
     inFlight.delete(url);
@@ -52,10 +55,12 @@ export async function dedupedGetJson(
 }
 
 /**
- * Drop any cached/in-flight result for a URL. Call after something invalidates it
- * (a mutation, or an auth change such as sign-out) so the next read fetches fresh.
+ * Wipe the entire cache. The store is a module-level singleton shared across the
+ * client session, so it MUST be cleared on any auth change (sign-in/out) — otherwise
+ * a newly signed-in user could be served the previous user's cached response (e.g.
+ * their profile) within the TTL window.
  */
-export function invalidateGet(url: string): void {
-  cache.delete(url);
-  inFlight.delete(url);
+export function clearGetCache(): void {
+  cache.clear();
+  inFlight.clear();
 }

--- a/lib/utils/deduped-get.ts
+++ b/lib/utils/deduped-get.ts
@@ -1,0 +1,61 @@
+/**
+ * Collapse redundant client-side GETs of the same URL.
+ *
+ * The dashboard mounts several copies of the auth/onboarding hooks, and each one
+ * fired its own request on mount — plus again on Supabase's INITIAL_SESSION event.
+ * The result was `/api/auth/profile` fetched ~7x and `/api/onboarding/status` ~4x
+ * on a single load. A per-URL in-flight promise collapses the simultaneous burst;
+ * a short TTL cache absorbs the near-sequential stragglers. The TTL is deliberately
+ * tiny so a genuinely new navigation still refetches fresh data.
+ */
+
+type Result = { ok: boolean; status: number; body: unknown };
+
+const inFlight = new Map<string, Promise<Result>>();
+const cache = new Map<string, { at: number; value: Result }>();
+
+const DEFAULT_TTL_MS = 5_000;
+
+export async function dedupedGetJson(
+  url: string,
+  ttlMs: number = DEFAULT_TTL_MS
+): Promise<Result> {
+  const cached = cache.get(url);
+  if (cached && Date.now() - cached.at < ttlMs) {
+    return cached.value;
+  }
+
+  const existing = inFlight.get(url);
+  if (existing) return existing;
+
+  const request = (async (): Promise<Result> => {
+    const res = await fetch(url, { method: "GET", credentials: "include" });
+    let body: unknown = null;
+    try {
+      body = await res.json();
+    } catch {
+      body = null;
+    }
+    return { ok: res.ok, status: res.status, body };
+  })();
+
+  inFlight.set(url, request);
+  try {
+    const value = await request;
+    // Only successful reads are cached; a thrown request leaves no entry so the
+    // next caller retries.
+    cache.set(url, { at: Date.now(), value });
+    return value;
+  } finally {
+    inFlight.delete(url);
+  }
+}
+
+/**
+ * Drop any cached/in-flight result for a URL. Call after something invalidates it
+ * (a mutation, or an auth change such as sign-out) so the next read fetches fresh.
+ */
+export function invalidateGet(url: string): void {
+  cache.delete(url);
+  inFlight.delete(url);
+}

--- a/lib/utils/deduped-get.ts
+++ b/lib/utils/deduped-get.ts
@@ -14,7 +14,18 @@ type Result = { ok: boolean; status: number; body: unknown };
 const inFlight = new Map<string, Promise<Result>>();
 const cache = new Map<string, { at: number; value: Result }>();
 
+// Bumped by clearGetCache() on every auth change. A request captures the epoch at
+// start; if it changes before the request resolves, the auth session turned over
+// mid-flight (e.g. sign-out) and the response belongs to the previous user — so we
+// must not cache it, and callers must not apply it. Guards against CWE-362: a slow
+// account-A response completing after sign-out (or after account B signs in).
+let epoch = 0;
+
 const DEFAULT_TTL_MS = 5_000;
+
+export function getGetCacheEpoch(): number {
+  return epoch;
+}
 
 export async function dedupedGetJson(
   url: string,
@@ -28,6 +39,7 @@ export async function dedupedGetJson(
   const existing = inFlight.get(url);
   if (existing) return existing;
 
+  const startEpoch = epoch;
   const request = (async (): Promise<Result> => {
     const res = await fetch(url, { method: "GET", credentials: "include" });
     let body: unknown = null;
@@ -42,25 +54,32 @@ export async function dedupedGetJson(
   inFlight.set(url, request);
   try {
     const value = await request;
-    // Cache only successful reads. A 4xx/5xx (value.ok === false) or a thrown
-    // request leaves no entry, so the next caller retries instead of being pinned
-    // to a failure for the whole TTL.
-    if (value.ok) {
+    // Cache only a successful read from the still-current auth session. A 4xx/5xx,
+    // a thrown request, or an auth turnover mid-flight (epoch changed) leaves no
+    // entry, so the next caller retries / fetches fresh rather than being pinned to
+    // a stale-or-failed value for the whole TTL.
+    if (value.ok && epoch === startEpoch) {
       cache.set(url, { at: Date.now(), value });
     }
     return value;
   } finally {
-    inFlight.delete(url);
+    // Only reclaim our own in-flight slot; if clearGetCache() ran, the map was
+    // already wiped and a newer request may own this URL.
+    if (epoch === startEpoch) {
+      inFlight.delete(url);
+    }
   }
 }
 
 /**
- * Wipe the entire cache. The store is a module-level singleton shared across the
- * client session, so it MUST be cleared on any auth change (sign-in/out) — otherwise
- * a newly signed-in user could be served the previous user's cached response (e.g.
- * their profile) within the TTL window.
+ * Wipe the cache and advance the auth epoch. The store is a module-level singleton
+ * shared across the client session, so it MUST be cleared on any auth change
+ * (sign-in/out) — otherwise a newly signed-in user could be served the previous
+ * user's cached response (e.g. their profile). Advancing the epoch also neutralizes
+ * any request already in flight so its late response can't repopulate the cache.
  */
 export function clearGetCache(): void {
+  epoch++;
   cache.clear();
   inFlight.clear();
 }


### PR DESCRIPTION
## Why
Found during the smoke test: a single dashboard load fired **`/api/auth/profile` ~7×** and **`/api/onboarding/status` ~4×**. Multiple components mount the auth hooks, and each fetches on mount *and* again on Supabase's initial auth event; the onboarding effect also re-runs as the `user` reference settles.

## What
- New `lib/utils/deduped-get.ts`: per-URL in-flight promise (collapses the simultaneous burst) + tiny 5s TTL cache (absorbs near-sequential stragglers). Returns `{ok,status,body}` so callers keep their 404 handling.
- Both auth hooks and `useOnboardingTrigger` route their GET through it; profile cache is invalidated on sign-out so a later sign-in is fresh.

No behavior change beyond fewer duplicate requests. Verifiable on the preview: reload the dashboard and count network calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced duplicate onboarding and profile requests.
  * Added short-term caching for repeated data requests.

* **Bug Fixes**
  * Improved handling of unsuccessful or incomplete responses.
  * Cleared cached profile data when signing out, preventing stale information from being displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->