### PR TITLE
fix(ai-coach): tab bar overflow on mobile

### DIFF
--- a/components/ai-coach/ai-coach-dashboard.tsx
+++ b/components/ai-coach/ai-coach-dashboard.tsx
@@ -122,25 +122,25 @@ function AICoachDashboardInner({ userId }: AICoachDashboardProps) {
         onValueChange={handleTabChange}
         className="space-y-6"
       >
-        <div className="flex items-center justify-between gap-3 flex-wrap">
-          <TabsList className="grid grid-cols-5 flex-1 h-auto p-1 gap-1">
-          <TabsTrigger value="resume" className="flex flex-col sm:flex-row items-center justify-center gap-1 sm:gap-2 px-2 py-3 sm:py-2 min-w-[60px] sm:min-w-[80px]">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <TabsList className="grid grid-cols-5 w-full sm:flex-1 h-auto p-1 gap-1">
+          <TabsTrigger value="resume" className="flex flex-col sm:flex-row items-center justify-center gap-1 sm:gap-2 px-1 sm:px-2 py-3 sm:py-2 min-w-0 sm:min-w-[80px]">
             <FileText className="h-4 w-4 flex-shrink-0" />
             <span className="text-[10px] sm:text-xs md:text-sm leading-tight text-center">Resume</span>
           </TabsTrigger>
-          <TabsTrigger value="interview" className="flex flex-col sm:flex-row items-center justify-center gap-1 sm:gap-2 px-2 py-3 sm:py-2 min-w-[60px] sm:min-w-[80px]">
+          <TabsTrigger value="interview" className="flex flex-col sm:flex-row items-center justify-center gap-1 sm:gap-2 px-1 sm:px-2 py-3 sm:py-2 min-w-0 sm:min-w-[80px]">
             <Briefcase className="h-4 w-4 flex-shrink-0" />
             <span className="text-[10px] sm:text-xs md:text-sm leading-tight text-center">Interview</span>
           </TabsTrigger>
-          <TabsTrigger value="cover-letter" className="flex flex-col sm:flex-row items-center justify-center gap-1 sm:gap-2 px-2 py-3 sm:py-2 min-w-[60px] sm:min-w-[80px]">
+          <TabsTrigger value="cover-letter" className="flex flex-col sm:flex-row items-center justify-center gap-1 sm:gap-2 px-1 sm:px-2 py-3 sm:py-2 min-w-0 sm:min-w-[80px]">
             <Mail className="h-4 w-4 flex-shrink-0" />
             <span className="text-[10px] sm:text-xs md:text-sm leading-tight text-center">Cover</span>
           </TabsTrigger>
-          <TabsTrigger value="job-fit" className="flex flex-col sm:flex-row items-center justify-center gap-1 sm:gap-2 px-2 py-3 sm:py-2 min-w-[60px] sm:min-w-[80px]">
+          <TabsTrigger value="job-fit" className="flex flex-col sm:flex-row items-center justify-center gap-1 sm:gap-2 px-1 sm:px-2 py-3 sm:py-2 min-w-0 sm:min-w-[80px]">
             <BarChart3 className="h-4 w-4 flex-shrink-0" />
             <span className="text-[10px] sm:text-xs md:text-sm leading-tight text-center">Job Fit</span>
           </TabsTrigger>
-          <TabsTrigger value="advice" className="flex flex-col sm:flex-row items-center justify-center gap-1 sm:gap-2 px-2 py-3 sm:py-2 min-w-[60px] sm:min-w-[80px]">
+          <TabsTrigger value="advice" className="flex flex-col sm:flex-row items-center justify-center gap-1 sm:gap-2 px-1 sm:px-2 py-3 sm:py-2 min-w-0 sm:min-w-[80px]">
             <MessageSquare className="h-4 w-4 flex-shrink-0" />
             <span className="text-[10px] sm:text-xs md:text-sm leading-tight text-center">Advice</span>
           </TabsTrigger>


### PR DESCRIPTION
## Why
Reported: the AI Coach tab bar (Resume/Interview/Cover/Job Fit/Advice + 'free analyses remaining' pill) doesn't fit on mobile.

## What
- The row was `flex justify-between` with a 5-col grid **and** the wide pill competing for width. Now it **stacks on mobile** (tabs full-width row, pill below) and stays inline on `sm+`.
- Tabs drop the `min-w-[60px]` floor on mobile (`min-w-0` + tighter padding) so the five columns shrink to fit any width instead of forcing ~300px and overflowing; `sm:min-w-[80px]` unchanged for desktop.

No desktop change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved AI Coach dashboard tab navigation responsiveness across mobile and larger screen sizes.
  * Adjusted tab sizing, spacing, and text/icon alignment for better usability on different devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->