### PR TITLE
copy: reposition hero as career companion across all stages

### DIFF
--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -116,12 +116,12 @@ export default function HomePage() {
                   className="font-display font-bold text-foreground leading-[1.05]"
                   style={{ fontSize: "clamp(2.5rem, 5vw, 3.75rem)", letterSpacing: "-0.02em" }}
                 >
-                  Build the case for your next raise. Then win it.
+                  Your companion for every stage of your career.
                 </h1>
                 <p className="text-[18px] leading-relaxed text-muted-foreground max-w-[520px]">
-                  Log wins in ten seconds. CareerOtter maps them to your review,
-                  names the gaps while there&apos;s time to close them, and hands you
-                  the doc to walk in with.
+                  Land the job, log the wins, and make the case for what&apos;s
+                  next — CareerOtter is with you from first application to
+                  promotion.
                 </p>
                 <div className="flex flex-col gap-4 sm:flex-row">
                   <Link

--- a/lib/constants/site-config.ts
+++ b/lib/constants/site-config.ts
@@ -31,12 +31,12 @@ export function getAppUrl(): string {
 
 export const SITE_CONFIG = {
   name: "CareerOtter",
-  title: "CareerOtter - Build the case for your next raise. Then win it.",
+  title: "CareerOtter - Your companion for every stage of your career.",
   description:
-    "Log your wins in ten seconds. CareerOtter maps them to your review, names the gaps while there's time to close them, and hands you the doc to walk in with.",
+    "Land the job, log the wins, and make the case for what's next. CareerOtter is with you from first application to promotion — application tracking, win logging, and AI coaching in one place.",
   shortDescription:
-    "Build the case for your next raise or promotion, then win it.",
-  tagline: "Build the case for your next raise. Then win it.",
+    "Your companion for every stage of your career, from first application to promotion.",
+  tagline: "Your companion for every stage of your career.",
   url: SITE_URL,
   ogImage: `${SITE_URL}/opengraph-image`,
 


### PR DESCRIPTION
## Why
'Build the case for your next raise. Then win it.' scoped the product to a single stage (the promo/review moment). Reposition around being the **companion for every stage of a career**.

## What
- Hero headline → **"Your companion for every stage of your career."**
- Hero sub → "Land the job, log the wins, and make the case for what's next — CareerOtter is with you from first application to promotion."
- `site-config` title / description / shortDescription / tagline updated to match (SEO + OG).

## Note
The rest of the page (value props, case-coverage card, pricing) is still raise/promo-centric, so it now slightly out-runs the broader hero. A light body-copy pass is a sensible follow-up if we want the whole page to speak to all stages.