### PR TITLE
feat: close TrueUp competitive gaps (coach memory, guided flows, tailored resumes, comp projections)

### DIFF
--- a/__tests__/components/coach-chat-memory.test.tsx
+++ b/__tests__/components/coach-chat-memory.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Behavior contract for coach memory restore (coach-chat.tsx).
+ *
+ * A restored session must keep running its guided flow: when GET returns a
+ * stored goalId, the next message the user sends must include that goalId in
+ * the POST body. Start-fresh must not clear local state if the DELETE fails.
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { CoachChat } from "@/components/careerotter/coach-chat";
+
+function mockFetchSequence(handlers: Record<string, (init?: RequestInit) => unknown>) {
+  return jest.fn(async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? "GET";
+    const key = `${method} ${url}`;
+    const body = handlers[key]?.(init);
+    if (body === undefined) throw new Error(`Unexpected fetch: ${key}`);
+    const { __status, ...json } = body as { __status?: number } & Record<string, unknown>;
+    return {
+      ok: (__status ?? 200) < 400,
+      status: __status ?? 200,
+      json: async () => json,
+    };
+  });
+}
+
+describe("CoachChat memory restore", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("sends the restored goalId with the next message", async () => {
+    const posts: unknown[] = [];
+    const fetchMock = mockFetchSequence({
+      "GET /api/careerotter/coach": () => ({
+        summary: "You were building your storybank.",
+        messages: [
+          { role: "user", content: "Turn my wins into interview stories." },
+          { role: "assistant", content: "Here is your first story." },
+        ],
+        goalId: "storybank",
+        updatedAt: "2026-08-07T00:00:00Z",
+      }),
+      "POST /api/careerotter/coach": (init) => {
+        posts.push(JSON.parse(String(init?.body)));
+        return { reply: "Next story." };
+      },
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<CoachChat />);
+    await screen.findByText("Pick up where you left off");
+
+    fireEvent.change(screen.getByLabelText("Message the coach"), {
+      target: { value: "Give me another one" },
+    });
+    fireEvent.submit(screen.getByLabelText("Message the coach").closest("form")!);
+
+    await waitFor(() => expect(posts.length).toBe(1));
+    expect(posts[0]).toMatchObject({ goalId: "storybank" });
+  });
+
+  it("keeps the session when start-fresh DELETE fails", async () => {
+    const fetchMock = mockFetchSequence({
+      "GET /api/careerotter/coach": () => ({
+        summary: "You were prepping your review.",
+        messages: [{ role: "user", content: "Help me prep." }],
+        goalId: null,
+        updatedAt: "2026-08-07T00:00:00Z",
+      }),
+      "DELETE /api/careerotter/coach": () => ({ __status: 500, error: "nope" }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<CoachChat />);
+    await screen.findByText("Pick up where you left off");
+
+    fireEvent.click(screen.getByRole("button", { name: "Start fresh" }));
+
+    await screen.findByText("Could not clear the saved session. Try again.");
+    expect(screen.getByText("Help me prep.")).toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/careerotter-coach-goals.test.ts
+++ b/__tests__/lib/careerotter-coach-goals.test.ts
@@ -1,0 +1,82 @@
+// @jest-environment node
+import {
+  buildCoachSystemPrompt,
+  getCoachGoal,
+  COACH_GOALS,
+} from "@/lib/careerotter/coach-prompt";
+import { vestedFractionOfYear } from "@/components/careerotter/comp-tracker";
+
+describe("COACH_GOALS", () => {
+  it("has unique ids", () => {
+    const ids = COACH_GOALS.map((g) => g.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("every goal has a stage, kickoff, and guidance", () => {
+    for (const g of COACH_GOALS) {
+      expect(g.stage.length).toBeGreaterThan(0);
+      expect(g.kickoff.length).toBeGreaterThan(0);
+      expect(g.guidance.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("getCoachGoal", () => {
+  it("finds a goal by id", () => {
+    expect(getCoachGoal("storybank")?.label).toBe("Build my storybank");
+  });
+
+  it("returns null for unknown or non-string input", () => {
+    expect(getCoachGoal("nope")).toBeNull();
+    expect(getCoachGoal(undefined)).toBeNull();
+    expect(getCoachGoal(42)).toBeNull();
+  });
+});
+
+describe("buildCoachSystemPrompt with a guided activity", () => {
+  const wins = [{ text: "Shipped billing migration early", tag: "delivery" }];
+
+  it("appends the activity guidance", () => {
+    const goal = getCoachGoal("find-gaps");
+    const p = buildCoachSystemPrompt({ mode: "promotion" }, wins, goal);
+    expect(p).toContain('guided activity "Find my gaps"');
+    expect(p).toContain(goal!.guidance);
+  });
+
+  it("is unchanged when no activity is given", () => {
+    const p = buildCoachSystemPrompt({ mode: "promotion" }, wins);
+    expect(p).not.toContain("guided activity");
+  });
+});
+
+describe("vestedFractionOfYear", () => {
+  const start = new Date("2026-01-01T00:00:00");
+
+  it("is 1 for a year fully inside the vest window", () => {
+    expect(vestedFractionOfYear(2027, start, 4)).toBeCloseTo(1, 5);
+  });
+
+  it("is 0 for a year entirely after vesting ends", () => {
+    expect(vestedFractionOfYear(2031, start, 4)).toBe(0);
+  });
+
+  it("is 0 for a year entirely before vesting starts", () => {
+    expect(vestedFractionOfYear(2025, start, 4)).toBe(0);
+  });
+
+  it("prorates a partial first year for a mid-year start", () => {
+    const julyStart = new Date("2026-07-01T00:00:00");
+    const frac = vestedFractionOfYear(2026, julyStart, 4);
+    expect(frac).toBeGreaterThan(0.4);
+    expect(frac).toBeLessThan(0.6);
+  });
+
+  it("covers roughly vestYears of total time across the window", () => {
+    const years = [2026, 2027, 2028, 2029, 2030];
+    const total = years.reduce(
+      (sum, y) => sum + vestedFractionOfYear(y, start, 4),
+      0
+    );
+    expect(total).toBeCloseTo(4, 1);
+  });
+});

--- a/__tests__/lib/careerotter-coach-goals.test.ts
+++ b/__tests__/lib/careerotter-coach-goals.test.ts
@@ -4,7 +4,7 @@ import {
   getCoachGoal,
   COACH_GOALS,
 } from "@/lib/careerotter/coach-prompt";
-import { vestedFractionOfYear } from "@/components/careerotter/comp-tracker";
+import { grantFractionReceivedInYear } from "@/components/careerotter/comp-tracker";
 
 describe("COACH_GOALS", () => {
   it("has unique ids", () => {
@@ -49,34 +49,63 @@ describe("buildCoachSystemPrompt with a guided activity", () => {
   });
 });
 
-describe("vestedFractionOfYear", () => {
+describe("grantFractionReceivedInYear", () => {
   const start = new Date("2026-01-01T00:00:00");
 
-  it("is 1 for a year fully inside the vest window", () => {
-    expect(vestedFractionOfYear(2027, start, 4)).toBeCloseTo(1, 5);
+  it("gives roughly 1/vestYears for a full mid-vest year with no cliff", () => {
+    expect(grantFractionReceivedInYear(2027, start, 4, 0)).toBeCloseTo(0.25, 2);
   });
 
   it("is 0 for a year entirely after vesting ends", () => {
-    expect(vestedFractionOfYear(2031, start, 4)).toBe(0);
+    expect(grantFractionReceivedInYear(2031, start, 4, 0)).toBe(0);
   });
 
   it("is 0 for a year entirely before vesting starts", () => {
-    expect(vestedFractionOfYear(2025, start, 4)).toBe(0);
+    expect(grantFractionReceivedInYear(2025, start, 4, 0)).toBe(0);
   });
 
-  it("prorates a partial first year for a mid-year start", () => {
+  it("halves the first year's share for a mid-year start with no cliff", () => {
     const julyStart = new Date("2026-07-01T00:00:00");
-    const frac = vestedFractionOfYear(2026, julyStart, 4);
-    expect(frac).toBeGreaterThan(0.4);
-    expect(frac).toBeLessThan(0.6);
+    const frac = grantFractionReceivedInYear(2026, julyStart, 4, 0);
+    expect(frac).toBeGreaterThan(0.1);
+    expect(frac).toBeLessThan(0.15);
   });
 
-  it("covers roughly vestYears of total time across the window", () => {
+  it("sums to the full grant across the window", () => {
     const years = [2026, 2027, 2028, 2029, 2030];
     const total = years.reduce(
-      (sum, y) => sum + vestedFractionOfYear(y, start, 4),
+      (sum, y) => sum + grantFractionReceivedInYear(y, start, 4, 0),
       0
     );
-    expect(total).toBeCloseTo(4, 1);
+    expect(total).toBeCloseTo(1, 5);
+  });
+
+  describe("with a 12-month cliff (Dec 2025 start, 4-year vest)", () => {
+    const decStart = new Date("2025-12-01T00:00:00");
+
+    it("pays nothing before the cliff", () => {
+      expect(grantFractionReceivedInYear(2025, decStart, 4, 12)).toBe(0);
+    });
+
+    it("pays the cliff lump (a year's worth plus remaining months) in the cliff year", () => {
+      const frac = grantFractionReceivedInYear(2026, decStart, 4, 12);
+      // ~13 of 48 months land in 2026: the 12-month lump at the Dec 2026
+      // cliff plus December's linear vesting.
+      expect(frac).toBeGreaterThan(0.25);
+      expect(frac).toBeLessThan(0.29);
+    });
+
+    it("returns to ~1/vestYears in later years", () => {
+      expect(grantFractionReceivedInYear(2027, decStart, 4, 12)).toBeCloseTo(0.25, 2);
+    });
+
+    it("still sums to the full grant across the window", () => {
+      const years = [2025, 2026, 2027, 2028, 2029, 2030];
+      const total = years.reduce(
+        (sum, y) => sum + grantFractionReceivedInYear(y, decStart, 4, 12),
+        0
+      );
+      expect(total).toBeCloseTo(1, 5);
+    });
   });
 });

--- a/app/(app)/dashboard/application/[id]/page.tsx
+++ b/app/(app)/dashboard/application/[id]/page.tsx
@@ -38,6 +38,7 @@ import { StatusSelector } from "@/components/status-selector"
 import { EditApplicationModal } from "@/components/edit-application-modal"
 import { archiveApplicationAction, deleteApplicationAction } from "@/lib/actions"
 import { Sparkles } from "lucide-react"
+import { TailoredResume } from "@/components/careerotter/tailored-resume"
 import { LinkedInContactsSection } from "@/components/linkedin-contacts-section"
 import { formatLocalDate, formatLocalDateTime } from "@/lib/utils/date"
 import { useFeatureFlag, FEATURE_FLAGS } from "@/lib/hooks/use-feature-flag"
@@ -343,6 +344,9 @@ export default function ApplicationDetailPage() {
               </div>
             </CardContent>
           </Card>
+
+          {/* Tailored resume draft for this application */}
+          <TailoredResume applicationId={application.id} />
 
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
             {/* Interview Notes */}

--- a/app/api/careerotter/coach/route.ts
+++ b/app/api/careerotter/coach/route.ts
@@ -55,10 +55,15 @@ function parseMessages(raw: unknown): Msg[] | null {
 }
 
 /**
- * Write the updated transcript and a fresh two-sentence summary to
- * coach_memory. Runs in after() — a failure here never blocks the reply.
+ * Write the updated transcript, the active guided-goal id, and a fresh
+ * two-sentence summary to coach_memory. Runs in after() — a failure here
+ * never blocks the reply.
  */
-async function persistMemory(userId: string, transcript: Msg[]): Promise<void> {
+async function persistMemory(
+  userId: string,
+  transcript: Msg[],
+  goalId: string | null
+): Promise<void> {
   const admin = createAdminClient();
   const messages = transcript.slice(-MAX_MESSAGES);
   try {
@@ -87,6 +92,7 @@ async function persistMemory(userId: string, transcript: Msg[]): Promise<void> {
     const { error } = await admin.from("coach_memory").upsert({
       user_id: userId,
       messages,
+      goal_id: goalId,
       ...(summary ? { summary } : {}),
       updated_at: new Date().toISOString(),
     });
@@ -100,6 +106,7 @@ async function persistMemory(userId: string, transcript: Msg[]): Promise<void> {
   }
 }
 
+/** Return the signed-in user's coach memory (summary, transcript, active goal). */
 export async function GET() {
   const supabase = await createClient();
   const {
@@ -109,19 +116,30 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("coach_memory")
-    .select("summary, messages, updated_at")
+    .select("summary, messages, goal_id, updated_at")
     .eq("user_id", user.id)
     .maybeSingle();
+
+  if (error) {
+    loggerService.error("Coach memory load failed", error, {
+      category: LogCategory.DATABASE,
+      userId: user.id,
+      action: "coach_memory_load_failed",
+    });
+    return NextResponse.json({ error: "Could not load coach memory" }, { status: 500 });
+  }
 
   return NextResponse.json({
     summary: data?.summary ?? null,
     messages: Array.isArray(data?.messages) ? data?.messages : [],
+    goalId: data?.goal_id ?? null,
     updatedAt: data?.updated_at ?? null,
   });
 }
 
+/** Delete the signed-in user's coach memory ("start fresh"). */
 export async function DELETE() {
   const supabase = await createClient();
   const {
@@ -138,6 +156,7 @@ export async function DELETE() {
   return NextResponse.json({ ok: true });
 }
 
+/** Generate a coach reply, then persist the transcript + summary. Pro-only. */
 export async function POST(request: NextRequest) {
   const supabase = await createClient();
   const {
@@ -205,7 +224,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  after(
+  after(() =>
     captureServerEvent(user.id, CAREEROTTER_EVENT_NAMES.COACH_MESSAGE_SENT, {
       prompt_version: COACH_PROMPT_VERSION,
       turns: messages.length,
@@ -213,7 +232,13 @@ export async function POST(request: NextRequest) {
       goal_id: goal?.id ?? null,
     })
   );
-  after(persistMemory(user.id, [...messages, { role: "assistant", content: reply }]));
+  after(() =>
+    persistMemory(
+      user.id,
+      [...messages, { role: "assistant", content: reply }],
+      goal?.id ?? null
+    )
+  );
 
   return NextResponse.json({ reply });
 }

--- a/app/api/careerotter/coach/route.ts
+++ b/app/api/careerotter/coach/route.ts
@@ -54,6 +54,17 @@ function parseMessages(raw: unknown): Msg[] | null {
   return out;
 }
 
+/** Narrow an unknown stored value to a well-formed transcript message. */
+function isMsg(value: unknown): value is Msg {
+  if (typeof value !== "object" || value === null) return false;
+  const { role, content } = value as { role?: unknown; content?: unknown };
+  return (
+    (role === "user" || role === "assistant") &&
+    typeof content === "string" &&
+    content.trim().length > 0
+  );
+}
+
 /**
  * Validate a stored transcript before returning it to the client. The RLS
  * policies let a user write arbitrary JSONB into their own coach_memory row,
@@ -66,12 +77,8 @@ function sanitizeStoredMessages(raw: unknown): Msg[] {
   }
   const out: Msg[] = [];
   for (const m of raw) {
-    const role = (m as { role?: unknown })?.role;
-    const content = (m as { content?: unknown })?.content;
-    if ((role !== "user" && role !== "assistant") || typeof content !== "string" || !content.trim()) {
-      return [];
-    }
-    out.push({ role, content: content.slice(0, MAX_CONTENT) });
+    if (!isMsg(m)) return [];
+    out.push({ role: m.role, content: m.content.slice(0, MAX_CONTENT) });
   }
   return out;
 }
@@ -156,7 +163,9 @@ export async function GET() {
   return NextResponse.json({
     summary: typeof data?.summary === "string" ? data.summary : null,
     messages: sanitizeStoredMessages(data?.messages),
-    goalId: typeof data?.goal_id === "string" ? data.goal_id : null,
+    // Validate against the goal catalog: POST only stores resolved goal ids,
+    // but the RLS policies let a user write any string into their own row.
+    goalId: getCoachGoal(data?.goal_id)?.id ?? null,
     updatedAt: data?.updated_at ?? null,
   });
 }

--- a/app/api/careerotter/coach/route.ts
+++ b/app/api/careerotter/coach/route.ts
@@ -55,6 +55,28 @@ function parseMessages(raw: unknown): Msg[] | null {
 }
 
 /**
+ * Validate a stored transcript before returning it to the client. The RLS
+ * policies let a user write arbitrary JSONB into their own coach_memory row,
+ * so shape and size cannot be assumed. Any malformed transcript comes back
+ * as [] (a fresh session) rather than propagating unvalidated data.
+ */
+function sanitizeStoredMessages(raw: unknown): Msg[] {
+  if (!Array.isArray(raw) || raw.length === 0 || raw.length > MAX_MESSAGES) {
+    return [];
+  }
+  const out: Msg[] = [];
+  for (const m of raw) {
+    const role = (m as { role?: unknown })?.role;
+    const content = (m as { content?: unknown })?.content;
+    if ((role !== "user" && role !== "assistant") || typeof content !== "string" || !content.trim()) {
+      return [];
+    }
+    out.push({ role, content: content.slice(0, MAX_CONTENT) });
+  }
+  return out;
+}
+
+/**
  * Write the updated transcript, the active guided-goal id, and a fresh
  * two-sentence summary to coach_memory. Runs in after() — a failure here
  * never blocks the reply.
@@ -132,9 +154,9 @@ export async function GET() {
   }
 
   return NextResponse.json({
-    summary: data?.summary ?? null,
-    messages: Array.isArray(data?.messages) ? data?.messages : [],
-    goalId: data?.goal_id ?? null,
+    summary: typeof data?.summary === "string" ? data.summary : null,
+    messages: sanitizeStoredMessages(data?.messages),
+    goalId: typeof data?.goal_id === "string" ? data.goal_id : null,
     updatedAt: data?.updated_at ?? null,
   });
 }

--- a/app/api/careerotter/coach/route.ts
+++ b/app/api/careerotter/coach/route.ts
@@ -1,10 +1,14 @@
 /**
  * Coach v1 (CareerOtter Phase 2, M3).
  *
- * POST /api/careerotter/coach   { messages: {role, content}[] }
+ * POST   /api/careerotter/coach   { messages: {role, content}[] }
+ * GET    /api/careerotter/coach   -> { summary, messages, updatedAt } (coach memory)
+ * DELETE /api/careerotter/coach   clears coach memory (start fresh)
  *
  * Pro-only (it calls the model). Grounded exclusively in the user's logged wins,
  * goal, and review date via buildCoachSystemPrompt. Returns the assistant reply.
+ * Each exchange is persisted to coach_memory with a short model-written summary
+ * so the next session picks up where the user left off.
  */
 
 import { type NextRequest, NextResponse, after } from "next/server";
@@ -12,7 +16,12 @@ import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin-client";
 import { PermissionMiddleware } from "@/lib/middleware/permissions";
 import { callOpenAI } from "@/lib/openai/client";
-import { buildCoachSystemPrompt, COACH_PROMPT_VERSION } from "@/lib/careerotter/coach-prompt";
+import { Models } from "@/lib/openai/models";
+import {
+  buildCoachSystemPrompt,
+  getCoachGoal,
+  COACH_PROMPT_VERSION,
+} from "@/lib/careerotter/coach-prompt";
 import { CAREEROTTER_EVENT_NAMES } from "@/lib/analytics/careerotter-event-names";
 import { captureServerEvent } from "@/lib/analytics/posthog-server";
 import { loggerService } from "@/lib/services/logger.service";
@@ -45,6 +54,90 @@ function parseMessages(raw: unknown): Msg[] | null {
   return out;
 }
 
+/**
+ * Write the updated transcript and a fresh two-sentence summary to
+ * coach_memory. Runs in after() — a failure here never blocks the reply.
+ */
+async function persistMemory(userId: string, transcript: Msg[]): Promise<void> {
+  const admin = createAdminClient();
+  const messages = transcript.slice(-MAX_MESSAGES);
+  try {
+    let summary: string | null = null;
+    try {
+      summary = await callOpenAI({
+        systemPrompt:
+          "Summarize this career-coaching conversation in at most two sentences, written to the user in second person, so they can pick up where they left off next session. Name their goal and the concrete next step if one was agreed. No preamble.",
+        messages: [
+          {
+            role: "user",
+            content: messages
+              .map((m) => `${m.role === "user" ? "User" : "Coach"}: ${m.content}`)
+              .join("\n"),
+          },
+        ],
+        model: Models.fast,
+        maxTokens: 120,
+        temperature: 0.2,
+      });
+    } catch {
+      // Keep the prior summary if the summarizer call fails; the transcript
+      // below is the source of truth.
+    }
+
+    const { error } = await admin.from("coach_memory").upsert({
+      user_id: userId,
+      messages,
+      ...(summary ? { summary } : {}),
+      updated_at: new Date().toISOString(),
+    });
+    if (error) throw error;
+  } catch (error) {
+    loggerService.error("Coach memory persistence failed", error, {
+      category: LogCategory.AI_SERVICE,
+      userId,
+      action: "coach_memory_persist_failed",
+    });
+  }
+}
+
+export async function GET() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data } = await supabase
+    .from("coach_memory")
+    .select("summary, messages, updated_at")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  return NextResponse.json({
+    summary: data?.summary ?? null,
+    messages: Array.isArray(data?.messages) ? data?.messages : [],
+    updatedAt: data?.updated_at ?? null,
+  });
+}
+
+export async function DELETE() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { error } = await supabase.from("coach_memory").delete().eq("user_id", user.id);
+  if (error) {
+    return NextResponse.json({ error: "Could not clear coach memory" }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true });
+}
+
 export async function POST(request: NextRequest) {
   const supabase = await createClient();
   const {
@@ -63,13 +156,14 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  let body: { messages?: unknown };
+  let body: { messages?: unknown; goalId?: unknown };
   try {
     body = await request.json();
   } catch {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
   const messages = parseMessages(body.messages);
+  const goal = getCoachGoal(body.goalId);
   if (!messages) {
     return NextResponse.json(
       { error: "messages must be a non-empty list ending with a user turn" },
@@ -94,7 +188,7 @@ export async function POST(request: NextRequest) {
   let reply = "";
   try {
     reply = await callOpenAI({
-      systemPrompt: buildCoachSystemPrompt(profile ?? null, wins ?? []),
+      systemPrompt: buildCoachSystemPrompt(profile ?? null, wins ?? [], goal),
       messages,
       maxTokens: 900,
       temperature: 0.5,
@@ -116,8 +210,10 @@ export async function POST(request: NextRequest) {
       prompt_version: COACH_PROMPT_VERSION,
       turns: messages.length,
       has_wins: (wins?.length ?? 0) > 0,
+      goal_id: goal?.id ?? null,
     })
   );
+  after(persistMemory(user.id, [...messages, { role: "assistant", content: reply }]));
 
   return NextResponse.json({ reply });
 }

--- a/app/api/careerotter/comp/route.ts
+++ b/app/api/careerotter/comp/route.ts
@@ -44,7 +44,7 @@ export async function GET(request: NextRequest) {
   const { data: entries } = await admin
     .from("comp_entries")
     .select(
-      "id, effective_date, base, bonus, equity, currency, note, ticker, shares, vest_start, vest_years"
+      "id, effective_date, base, bonus, equity, currency, note, ticker, shares, vest_start, vest_years, vest_cliff_months"
     )
     .eq("user_id", user.id)
     .order("effective_date", { ascending: true });
@@ -94,6 +94,7 @@ type PostBody = {
   shares?: unknown;
   vest_start?: unknown;
   vest_years?: unknown;
+  vest_cliff_months?: unknown;
 };
 
 function num(v: unknown): number | null {
@@ -184,6 +185,21 @@ export async function POST(request: NextRequest) {
     }
     vestYears = body.vest_years;
   }
+  let vestCliffMonths: number | null = null;
+  if (body.vest_cliff_months !== undefined && body.vest_cliff_months !== null) {
+    if (
+      typeof body.vest_cliff_months !== "number" ||
+      !Number.isInteger(body.vest_cliff_months) ||
+      body.vest_cliff_months < 0 ||
+      body.vest_cliff_months > 60
+    ) {
+      return NextResponse.json(
+        { error: "vest_cliff_months must be a whole number between 0 and 60" },
+        { status: 400 }
+      );
+    }
+    vestCliffMonths = body.vest_cliff_months;
+  }
 
   const admin = createAdminClient();
   const { data, error } = await admin
@@ -199,9 +215,10 @@ export async function POST(request: NextRequest) {
       shares,
       vest_start: vestStart,
       vest_years: vestYears,
+      vest_cliff_months: vestCliffMonths,
     })
     .select(
-      "id, effective_date, base, bonus, equity, currency, note, ticker, shares, vest_start, vest_years"
+      "id, effective_date, base, bonus, equity, currency, note, ticker, shares, vest_start, vest_years, vest_cliff_months"
     )
     .single();
 

--- a/app/api/careerotter/comp/route.ts
+++ b/app/api/careerotter/comp/route.ts
@@ -32,7 +32,9 @@ export async function GET(request: NextRequest) {
   const admin = createAdminClient();
   const { data: entries } = await admin
     .from("comp_entries")
-    .select("id, effective_date, base, bonus, equity, currency, note, ticker, shares")
+    .select(
+      "id, effective_date, base, bonus, equity, currency, note, ticker, shares, vest_start, vest_years"
+    )
     .eq("user_id", user.id)
     .order("effective_date", { ascending: true });
 
@@ -79,6 +81,8 @@ type PostBody = {
   note?: unknown;
   ticker?: unknown;
   shares?: unknown;
+  vest_start?: unknown;
+  vest_years?: unknown;
 };
 
 function num(v: unknown): number | null {
@@ -142,6 +146,34 @@ export async function POST(request: NextRequest) {
     shares = body.shares;
   }
 
+  // Optional vesting schedule. vest_years is bounded to a sane grant length;
+  // vest_start must be a plain date. Invalid values are rejected, not dropped.
+  let vestStart: string | null = null;
+  if (body.vest_start !== undefined && body.vest_start !== null && body.vest_start !== "") {
+    if (typeof body.vest_start !== "string" || !ISO_DATE.test(body.vest_start)) {
+      return NextResponse.json(
+        { error: "vest_start must be YYYY-MM-DD" },
+        { status: 400 }
+      );
+    }
+    vestStart = body.vest_start;
+  }
+  let vestYears: number | null = null;
+  if (body.vest_years !== undefined && body.vest_years !== null) {
+    if (
+      typeof body.vest_years !== "number" ||
+      !Number.isFinite(body.vest_years) ||
+      body.vest_years <= 0 ||
+      body.vest_years > 10
+    ) {
+      return NextResponse.json(
+        { error: "vest_years must be a number between 0 and 10" },
+        { status: 400 }
+      );
+    }
+    vestYears = body.vest_years;
+  }
+
   const admin = createAdminClient();
   const { data, error } = await admin
     .from("comp_entries")
@@ -154,8 +186,12 @@ export async function POST(request: NextRequest) {
       note,
       ticker,
       shares,
+      vest_start: vestStart,
+      vest_years: vestYears,
     })
-    .select("id, effective_date, base, bonus, equity, currency, note, ticker, shares")
+    .select(
+      "id, effective_date, base, bonus, equity, currency, note, ticker, shares, vest_start, vest_years"
+    )
     .single();
 
   if (error) {

--- a/app/api/careerotter/comp/route.ts
+++ b/app/api/careerotter/comp/route.ts
@@ -22,6 +22,17 @@ import { LogCategory } from "@/lib/services/logger.types";
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
+/**
+ * True only for a real calendar date in YYYY-MM-DD form — the regex alone
+ * accepts impossible dates like 2026-02-29, which would then fail at insert
+ * time as a 500 instead of a validation 400.
+ */
+function isIsoDate(value: unknown): value is string {
+  if (typeof value !== "string" || !ISO_DATE.test(value)) return false;
+  const date = new Date(`${value}T00:00:00.000Z`);
+  return Number.isFinite(date.getTime()) && date.toISOString().slice(0, 10) === value;
+}
+
 export async function GET(request: NextRequest) {
   const supabase = await createClient();
   const {
@@ -104,9 +115,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  if (typeof body.effective_date !== "string" || !ISO_DATE.test(body.effective_date)) {
+  if (!isIsoDate(body.effective_date)) {
     return NextResponse.json(
-      { error: "effective_date must be YYYY-MM-DD" },
+      { error: "effective_date must be a valid YYYY-MM-DD date" },
       { status: 400 }
     );
   }
@@ -150,9 +161,9 @@ export async function POST(request: NextRequest) {
   // vest_start must be a plain date. Invalid values are rejected, not dropped.
   let vestStart: string | null = null;
   if (body.vest_start !== undefined && body.vest_start !== null && body.vest_start !== "") {
-    if (typeof body.vest_start !== "string" || !ISO_DATE.test(body.vest_start)) {
+    if (!isIsoDate(body.vest_start)) {
       return NextResponse.json(
-        { error: "vest_start must be YYYY-MM-DD" },
+        { error: "vest_start must be a valid YYYY-MM-DD date" },
         { status: 400 }
       );
     }

--- a/app/api/careerotter/tailored-resume/route.ts
+++ b/app/api/careerotter/tailored-resume/route.ts
@@ -29,6 +29,7 @@ const TAILOR_SYSTEM_PROMPT = `You rewrite resumes to target a specific job descr
 - Mirror the job description's terminology where the resume already demonstrates the skill (for keyword matching), but never claim skills the resume does not support.
 - Keep it to the same overall length or shorter than the original. Plain text, standard resume sections, no commentary before or after the resume itself.`;
 
+/** Return the saved tailored draft for one of the user's applications, if any. */
 export async function GET(request: NextRequest) {
   const supabase = await createClient();
   const {
@@ -57,6 +58,7 @@ export async function GET(request: NextRequest) {
   });
 }
 
+/** Generate (and save) a tailored draft for an application. Pro-only. */
 export async function POST(request: NextRequest) {
   const supabase = await createClient();
   const {
@@ -152,22 +154,25 @@ export async function POST(request: NextRequest) {
     },
     { onConflict: "user_id,application_id" }
   );
+  // The draft was generated either way — return it so the user can copy it,
+  // but tell the client honestly whether it was saved.
+  const persisted = !saveError;
   if (saveError) {
     loggerService.error("Tailored resume save failed", saveError, {
       category: LogCategory.DATABASE,
       userId: user.id,
       action: "tailored_resume_save_failed",
     });
-    // The draft was generated; return it even if persistence failed.
   }
 
-  after(
+  after(() =>
     captureServerEvent(user.id, "tailored_resume_generated", {
       application_id: applicationId,
       jd_length: jobDescription.length,
       resume_length: resumeText.length,
+      persisted,
     })
   );
 
-  return NextResponse.json({ tailoredText });
+  return NextResponse.json({ tailoredText, persisted });
 }

--- a/app/api/careerotter/tailored-resume/route.ts
+++ b/app/api/careerotter/tailored-resume/route.ts
@@ -1,0 +1,173 @@
+/**
+ * Per-application tailored resume drafts.
+ *
+ * POST /api/careerotter/tailored-resume  { applicationId }
+ * GET  /api/careerotter/tailored-resume?applicationId=...
+ *
+ * Pro-only (it calls the model), same gate as the coach. Generates a resume
+ * draft rewritten against the application's saved job description using the
+ * user's uploaded resume text, and keeps the latest draft per application.
+ */
+
+import { type NextRequest, NextResponse, after } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin-client";
+import { PermissionMiddleware } from "@/lib/middleware/permissions";
+import { callOpenAI } from "@/lib/openai/client";
+import { captureServerEvent } from "@/lib/analytics/posthog-server";
+import { loggerService } from "@/lib/services/logger.service";
+import { LogCategory } from "@/lib/services/logger.types";
+
+export const maxDuration = 60;
+
+const MIN_JD_LENGTH = 50;
+const MIN_RESUME_LENGTH = 100;
+
+const TAILOR_SYSTEM_PROMPT = `You rewrite resumes to target a specific job description. Rules:
+- Use ONLY facts, employers, dates, and accomplishments present in the original resume. Never invent experience, metrics, titles, or skills.
+- Reorder and reword so the experience most relevant to the job description leads each section.
+- Mirror the job description's terminology where the resume already demonstrates the skill (for keyword matching), but never claim skills the resume does not support.
+- Keep it to the same overall length or shorter than the original. Plain text, standard resume sections, no commentary before or after the resume itself.`;
+
+export async function GET(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const applicationId = request.nextUrl.searchParams.get("applicationId");
+  if (!applicationId) {
+    return NextResponse.json({ error: "applicationId is required" }, { status: 400 });
+  }
+
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("tailored_resumes")
+    .select("tailored_text, created_at")
+    .eq("user_id", user.id)
+    .eq("application_id", applicationId)
+    .maybeSingle();
+
+  return NextResponse.json({
+    tailoredText: data?.tailored_text ?? null,
+    createdAt: data?.created_at ?? null,
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const plan = await PermissionMiddleware.getUserPlanInfo(user.id);
+  if (!plan.isPro) {
+    return NextResponse.json(
+      { error: "Tailored resumes are a Pro feature.", requiredPlan: "Pro" },
+      { status: 403 }
+    );
+  }
+
+  let body: { applicationId?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  const applicationId = typeof body.applicationId === "string" ? body.applicationId : null;
+  if (!applicationId) {
+    return NextResponse.json({ error: "applicationId is required" }, { status: 400 });
+  }
+
+  const admin = createAdminClient();
+  const [{ data: application }, { data: resume }] = await Promise.all([
+    admin
+      .from("applications")
+      .select("company, role, job_description")
+      .eq("id", applicationId)
+      .eq("user_id", user.id)
+      .maybeSingle(),
+    admin
+      .from("user_resumes")
+      .select("extracted_text")
+      .eq("user_id", user.id)
+      .maybeSingle(),
+  ]);
+
+  if (!application) {
+    return NextResponse.json({ error: "Application not found" }, { status: 404 });
+  }
+  const jobDescription = application.job_description?.trim() ?? "";
+  if (jobDescription.length < MIN_JD_LENGTH) {
+    return NextResponse.json(
+      { error: "Save a job description on this application first." },
+      { status: 400 }
+    );
+  }
+  const resumeText = resume?.extracted_text?.trim() ?? "";
+  if (resumeText.length < MIN_RESUME_LENGTH) {
+    return NextResponse.json(
+      { error: "Upload a resume first so there is something to tailor." },
+      { status: 400 }
+    );
+  }
+
+  let tailoredText = "";
+  try {
+    tailoredText = await callOpenAI({
+      systemPrompt: TAILOR_SYSTEM_PROMPT,
+      messages: [
+        {
+          role: "user",
+          content: `Job: ${application.role} at ${application.company}\n\nJob description:\n${jobDescription}\n\nOriginal resume:\n${resumeText}`,
+        },
+      ],
+      maxTokens: 2500,
+      temperature: 0.3,
+    });
+  } catch (error) {
+    loggerService.error("Tailored resume generation failed", error, {
+      category: LogCategory.AI_SERVICE,
+      userId: user.id,
+      action: "tailored_resume_generation_failed",
+    });
+    return NextResponse.json(
+      { error: "Could not generate a draft right now. Please try again." },
+      { status: 502 }
+    );
+  }
+
+  const { error: saveError } = await admin.from("tailored_resumes").upsert(
+    {
+      user_id: user.id,
+      application_id: applicationId,
+      tailored_text: tailoredText,
+      created_at: new Date().toISOString(),
+    },
+    { onConflict: "user_id,application_id" }
+  );
+  if (saveError) {
+    loggerService.error("Tailored resume save failed", saveError, {
+      category: LogCategory.DATABASE,
+      userId: user.id,
+      action: "tailored_resume_save_failed",
+    });
+    // The draft was generated; return it even if persistence failed.
+  }
+
+  after(
+    captureServerEvent(user.id, "tailored_resume_generated", {
+      application_id: applicationId,
+      jd_length: jobDescription.length,
+      resume_length: resumeText.length,
+    })
+  );
+
+  return NextResponse.json({ tailoredText });
+}

--- a/components/auth-layout.tsx
+++ b/components/auth-layout.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import Image from "next/image";
+import { CareerOtterMark } from "@/components/careerotter-mark";
 
 interface AuthLayoutProps {
   children: React.ReactNode;
@@ -11,13 +11,7 @@ export function AuthLayout({ children }: AuthLayoutProps) {
       {/* Mobile header */}
       <div className="lg:hidden bg-primary/5 border-b border-border px-4 py-3">
         <Link href="/" className="flex items-center gap-2 min-h-11">
-          <Image
-            src="/logo_square.png"
-            alt="CareerOtter Logo"
-            width={28}
-            height={28}
-            className="rounded"
-          />
+          <CareerOtterMark decorative className="h-7 w-7" />
           <span className="font-semibold text-foreground">CareerOtter</span>
         </Link>
       </div>
@@ -26,12 +20,9 @@ export function AuthLayout({ children }: AuthLayoutProps) {
       <div className="hidden lg:flex lg:w-[45%] bg-section-cta text-section-cta-foreground flex-col justify-between p-10">
         <div>
           <Link href="/" className="flex items-center gap-2 min-h-11">
-            <Image
-              src="/logo_square.png"
-              alt="CareerOtter Logo"
-              width={32}
-              height={32}
-              className="rounded"
+            <CareerOtterMark
+              decorative
+              className="h-8 w-8 text-section-cta-foreground"
             />
             <span className="text-xl font-bold text-section-cta-foreground">
               CareerOtter
@@ -41,10 +32,11 @@ export function AuthLayout({ children }: AuthLayoutProps) {
 
         <div className="space-y-4">
           <h2 className="text-2xl font-bold font-display">
-            Track your applications. Visualize your pipeline. Land the role.
+            Your companion for every stage of your career.
           </h2>
           <p className="text-section-cta-foreground/70 leading-relaxed">
-            One place to organize your job search with AI-powered resume analysis, cover letters, and interview prep.
+            Land the job, log the wins, and make the case for what&apos;s next
+            &mdash; CareerOtter is with you from first application to promotion.
           </p>
         </div>
 

--- a/components/careerotter/coach-chat.tsx
+++ b/components/careerotter/coach-chat.tsx
@@ -1,25 +1,60 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
-import { COACH_STARTERS } from "@/lib/careerotter/coach-prompt";
+import { COACH_GOALS, COACH_STARTERS } from "@/lib/careerotter/coach-prompt";
 
 type Msg = { role: "user" | "assistant"; content: string };
 
+const GOAL_STAGES = [...new Set(COACH_GOALS.map((g) => g.stage))];
+
+// Keep in sync with MAX_MESSAGES in the coach API route.
+const MAX_SENT_MESSAGES = 30;
+
 /**
  * Coach chat (M3). Grounded server-side in the user's wins; this is just the
- * transcript + input. Seeded starters get a cold-start user moving.
+ * transcript + input. Seeded starters get a cold-start user moving. Prior
+ * sessions are restored from coach memory so the coach picks up where the
+ * user left off.
  */
 export function CoachChat() {
   const [messages, setMessages] = useState<Msg[]>([]);
+  const [summary, setSummary] = useState("");
+  const [restored, setRestored] = useState(false);
+  const [loadingMemory, setLoadingMemory] = useState(true);
   const [input, setInput] = useState("");
   const [sending, setSending] = useState(false);
   const [error, setError] = useState("");
+  // The guided activity currently steering the conversation, if any. Sent with
+  // every request while active so the coach keeps running that flow.
+  const [goalId, setGoalId] = useState<string | null>(null);
 
-  async function send(text: string) {
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/careerotter/coach");
+        const data = await res.json().catch(() => null);
+        if (!cancelled && res.ok && Array.isArray(data?.messages) && data.messages.length > 0) {
+          setMessages(data.messages);
+          setSummary(typeof data.summary === "string" ? data.summary : "");
+          setRestored(true);
+        }
+      } catch {
+        // No stored session — start cold.
+      } finally {
+        if (!cancelled) setLoadingMemory(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function send(text: string, activeGoalId: string | null = goalId) {
     const trimmed = text.trim();
     if (!trimmed || sending) return;
     setError("");
@@ -31,7 +66,10 @@ export function CoachChat() {
       const res = await fetch("/api/careerotter/coach", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ messages: next }),
+        body: JSON.stringify({
+          messages: next.slice(-MAX_SENT_MESSAGES),
+          ...(activeGoalId ? { goalId: activeGoalId } : {}),
+        }),
       });
       const data = await res.json().catch(() => null);
       if (res.ok && data?.reply) {
@@ -46,19 +84,65 @@ export function CoachChat() {
     }
   }
 
+  function startGoal(id: string) {
+    const goal = COACH_GOALS.find((g) => g.id === id);
+    if (!goal) return;
+    setGoalId(goal.id);
+    send(goal.kickoff, goal.id);
+  }
+
+  async function startFresh() {
+    setMessages([]);
+    setSummary("");
+    setRestored(false);
+    setError("");
+    setGoalId(null);
+    try {
+      await fetch("/api/careerotter/coach", { method: "DELETE" });
+    } catch {
+      // Local state is already cleared; a failed delete just means the old
+      // session reappears next visit.
+    }
+  }
+
+  if (loadingMemory) {
+    return <Spinner size="sm" />;
+  }
+
   return (
     <div className="space-y-4">
+      {restored && (
+        <Card className="bg-muted">
+          <CardContent className="space-y-2 p-4">
+            <p className="text-sm font-medium">Pick up where you left off</p>
+            {summary && (
+              <p className="text-sm text-muted-foreground">{summary}</p>
+            )}
+            <Button
+              variant="outline"
+              size="sm"
+              className="min-h-[44px]"
+              onClick={startFresh}
+              disabled={sending}
+            >
+              Start fresh
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
       {messages.length === 0 && (
-        <div className="space-y-3">
+        <div className="space-y-4">
           <p className="text-sm text-muted-foreground">
-            The coach reasons from what you have logged. Start here:
+            The coach reasons from what you have logged. Ask anything, or pick a
+            guided activity:
           </p>
           <div className="flex flex-col gap-2">
             {COACH_STARTERS.map((s) => (
               <Button
                 key={s}
                 variant="outline"
-                className="justify-start text-left"
+                className="min-h-[44px] justify-start text-left"
                 onClick={() => send(s)}
                 disabled={sending}
               >
@@ -66,6 +150,27 @@ export function CoachChat() {
               </Button>
             ))}
           </div>
+          {GOAL_STAGES.map((stage) => (
+            <div key={stage} className="space-y-2">
+              <h3 className="text-sm font-semibold">{stage}</h3>
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                {COACH_GOALS.filter((g) => g.stage === stage).map((g) => (
+                  <Button
+                    key={g.id}
+                    variant="outline"
+                    className="h-auto min-h-[44px] flex-col items-start gap-0.5 py-2 text-left"
+                    onClick={() => startGoal(g.id)}
+                    disabled={sending}
+                  >
+                    <span className="font-medium">{g.label}</span>
+                    <span className="text-xs font-normal text-muted-foreground">
+                      {g.description}
+                    </span>
+                  </Button>
+                ))}
+              </div>
+            </div>
+          ))}
         </div>
       )}
 

--- a/components/careerotter/coach-chat.tsx
+++ b/components/careerotter/coach-chat.tsx
@@ -41,6 +41,9 @@ export function CoachChat() {
         if (!cancelled && res.ok && Array.isArray(data?.messages) && data.messages.length > 0) {
           setMessages(data.messages);
           setSummary(typeof data.summary === "string" ? data.summary : "");
+          // Restore the active guided flow too, so the next message keeps
+          // running it instead of falling back to the generic prompt.
+          setGoalId(typeof data.goalId === "string" ? data.goalId : null);
           setRestored(true);
         }
       } catch {
@@ -92,17 +95,20 @@ export function CoachChat() {
   }
 
   async function startFresh() {
+    // Delete server-side memory first: clearing local state on a failed
+    // delete would just resurrect the old session on the next reload.
+    try {
+      const res = await fetch("/api/careerotter/coach", { method: "DELETE" });
+      if (!res.ok) throw new Error("delete failed");
+    } catch {
+      setError("Could not clear the saved session. Try again.");
+      return;
+    }
     setMessages([]);
     setSummary("");
     setRestored(false);
     setError("");
     setGoalId(null);
-    try {
-      await fetch("/api/careerotter/coach", { method: "DELETE" });
-    } catch {
-      // Local state is already cleared; a failed delete just means the old
-      // session reappears next visit.
-    }
   }
 
   if (loadingMemory) {

--- a/components/careerotter/comp-tracker.tsx
+++ b/components/careerotter/comp-tracker.tsx
@@ -164,7 +164,9 @@ export function CompTracker() {
           ticker: form.ticker.trim() || null,
           shares: Number(form.shares) || null,
           vest_start: form.vest_start || null,
-          vest_years: Number(form.vest_years) || null,
+          // "" means not provided; a typed 0 must reach the API so its
+          // validation error surfaces instead of silently storing no vesting.
+          vest_years: form.vest_years === "" ? null : Number(form.vest_years),
         }),
       });
       if (res.ok) {
@@ -257,7 +259,10 @@ export function CompTracker() {
       return grantValue;
     }
     if (vestYears && vestStartDate) {
-      return latestEquity * vestedFractionOfYear(year, vestStartDate, vestYears);
+      // Flat equity with a vest length is a total grant: annualize it the
+      // same way as share-based grants so the projection can never allocate
+      // more than the grant's value across the window.
+      return (latestEquity / vestYears) * vestedFractionOfYear(year, vestStartDate, vestYears);
     }
     return latestEquity;
   };

--- a/components/careerotter/comp-tracker.tsx
+++ b/components/careerotter/comp-tracker.tsx
@@ -31,6 +31,24 @@ interface CompEntry {
   note: string | null;
   ticker: string | null;
   shares: number | null;
+  vest_start: string | null;
+  vest_years: number | null;
+}
+
+/**
+ * Fraction of calendar year `year` that falls inside the vesting window
+ * [start, start + vestYears). 1 for fully-vesting years, prorated at the
+ * edges, 0 outside the window.
+ */
+export function vestedFractionOfYear(year: number, start: Date, vestYears: number): number {
+  const windowStart = start.getTime();
+  const windowEnd = new Date(start);
+  windowEnd.setMonth(windowEnd.getMonth() + Math.round(vestYears * 12));
+  const yearStart = new Date(year, 0, 1).getTime();
+  const yearEnd = new Date(year + 1, 0, 1).getTime();
+  const overlap =
+    Math.min(yearEnd, windowEnd.getTime()) - Math.max(yearStart, windowStart);
+  return Math.max(0, Math.min(1, overlap / (yearEnd - yearStart)));
 }
 
 const usd = (n: number) =>
@@ -73,10 +91,15 @@ export function CompTracker() {
     equity: "",
     ticker: "",
     shares: "",
+    vest_start: "",
+    vest_years: "",
   });
   const [error, setError] = useState("");
   const [saving, setSaving] = useState(false);
   const [scenarioPrice, setScenarioPrice] = useState<number | null>(null);
+  // Effective tax rate for the take-home row. An estimate the user controls —
+  // no jurisdiction math, no pretending to know their tax situation.
+  const [taxRate, setTaxRate] = useState(30);
   // Two-step delete: first click arms confirmId, second confirms. Avoids a modal
   // dependency while still guarding against an accidental permanent delete.
   const [confirmId, setConfirmId] = useState<string | null>(null);
@@ -140,6 +163,8 @@ export function CompTracker() {
           equity: Number(form.equity) || 0,
           ticker: form.ticker.trim() || null,
           shares: Number(form.shares) || null,
+          vest_start: form.vest_start || null,
+          vest_years: Number(form.vest_years) || null,
         }),
       });
       if (res.ok) {
@@ -150,6 +175,8 @@ export function CompTracker() {
           equity: "",
           ticker: "",
           shares: "",
+          vest_start: "",
+          vest_years: "",
         });
         await load();
       } else {
@@ -208,6 +235,44 @@ export function CompTracker() {
     ? Number(latest.base) + Number(latest.bonus) + latestShares * price
     : 0;
   const scenarioDelta = scenarioTotal - latestTotal;
+
+  // Multi-year projection. Salary and incentives are carried flat; stock is
+  // valued at the scenario price and prorated across the vesting window when a
+  // vest length is recorded (window starts at vest_start, else the entry date).
+  // Without a vest length the stock/equity number is carried flat, matching the
+  // single-year scenario semantics above.
+  const nowYear = new Date().getFullYear();
+  const projectionYears = [nowYear, nowYear + 1, nowYear + 2];
+  const vestYears = latest?.vest_years ? Number(latest.vest_years) : null;
+  const vestStartDate = latest
+    ? new Date(`${latest.vest_start ?? latest.effective_date}T00:00:00`)
+    : null;
+  const stockForYear = (year: number): number => {
+    if (!latest) return 0;
+    if (hasShares) {
+      const grantValue = latestShares * price;
+      if (vestYears && vestStartDate) {
+        return (grantValue / vestYears) * vestedFractionOfYear(year, vestStartDate, vestYears);
+      }
+      return grantValue;
+    }
+    if (vestYears && vestStartDate) {
+      return latestEquity * vestedFractionOfYear(year, vestStartDate, vestYears);
+    }
+    return latestEquity;
+  };
+  const projection = latest
+    ? projectionYears.map((year) => {
+        const stock = stockForYear(year);
+        return {
+          year,
+          salary: Number(latest.base),
+          incentives: Number(latest.bonus),
+          stock,
+          total: Number(latest.base) + Number(latest.bonus) + stock,
+        };
+      })
+    : [];
 
   return (
     <div className="space-y-6">
@@ -375,6 +440,103 @@ export function CompTracker() {
         </p>
       ) : null}
 
+      {/* Multi-year projection */}
+      {latest && (
+        <Card>
+          <CardContent className="space-y-3 p-5">
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">Projected comp</h3>
+              <p className="text-xs text-muted-foreground">
+                {vestYears
+                  ? `Stock prorated over a ${vestYears}-year vest${hasShares ? " at the scenario price above" : ""}.`
+                  : "Add a vest length to an entry to prorate stock across years."}
+              </p>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-xs text-muted-foreground">
+                    <th scope="col" className="py-1 pr-4 font-normal" />
+                    {projection.map((p) => (
+                      <th key={p.year} scope="col" className="py-1 pr-4 font-medium tabular-nums">
+                        {p.year}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th scope="row" className="py-1 pr-4 text-left font-normal text-muted-foreground">
+                      Salary
+                    </th>
+                    {projection.map((p) => (
+                      <td key={p.year} className="py-1 pr-4 tabular-nums">{usd(p.salary)}</td>
+                    ))}
+                  </tr>
+                  <tr>
+                    <th scope="row" className="py-1 pr-4 text-left font-normal text-muted-foreground">
+                      Incentives
+                    </th>
+                    {projection.map((p) => (
+                      <td key={p.year} className="py-1 pr-4 tabular-nums">{usd(p.incentives)}</td>
+                    ))}
+                  </tr>
+                  <tr>
+                    <th scope="row" className="py-1 pr-4 text-left font-normal text-muted-foreground">
+                      Stock
+                    </th>
+                    {projection.map((p) => (
+                      <td key={p.year} className="py-1 pr-4 tabular-nums">{usd(p.stock)}</td>
+                    ))}
+                  </tr>
+                  <tr className="border-t">
+                    <th scope="row" className="py-1.5 pr-4 text-left font-medium">
+                      Total
+                    </th>
+                    {projection.map((p) => (
+                      <td key={p.year} className="py-1.5 pr-4 font-semibold tabular-nums">
+                        {usd(p.total)}
+                      </td>
+                    ))}
+                  </tr>
+                  <tr>
+                    <th scope="row" className="py-1 pr-4 text-left font-normal text-muted-foreground">
+                      Est. take-home
+                    </th>
+                    {projection.map((p) => (
+                      <td key={p.year} className="py-1 pr-4 tabular-nums text-muted-foreground">
+                        {usd(p.total * (1 - taxRate / 100))}
+                      </td>
+                    ))}
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div className="flex items-center gap-2">
+              <Label htmlFor="tax-rate" className="text-xs text-muted-foreground">
+                Effective tax rate
+              </Label>
+              <Input
+                id="tax-rate"
+                type="number"
+                min="0"
+                max="60"
+                step="1"
+                value={taxRate}
+                onChange={(e) => {
+                  const v = Number(e.target.value);
+                  if (Number.isFinite(v)) setTaxRate(Math.min(60, Math.max(0, v)));
+                }}
+                className="min-h-[44px] w-20"
+              />
+              <span className="text-xs text-muted-foreground">
+                % — rough estimate, set it to match your actual rate
+              </span>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       {/* Entry form */}
       <form onSubmit={addEntry} className="space-y-3">
         <h3 className="text-sm font-semibold">Add a comp entry</h3>
@@ -417,9 +579,23 @@ export function CompTracker() {
               onChange={(e) => setForm({ ...form, shares: e.target.value })}
               className="min-h-[44px]" />
           </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="vest-start">Vest start (optional)</Label>
+            <Input id="vest-start" type="date" value={form.vest_start}
+              onChange={(e) => setForm({ ...form, vest_start: e.target.value })}
+              className="min-h-[44px]" />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="vest-years">Vest years (optional)</Label>
+            <Input id="vest-years" type="number" min="0" max="10" step="0.5" value={form.vest_years}
+              onChange={(e) => setForm({ ...form, vest_years: e.target.value })}
+              placeholder="e.g. 4"
+              className="min-h-[44px]" />
+          </div>
         </div>
         <p className="text-xs text-muted-foreground">
           Enter a ticker and share count to model equity by stock price, or leave Equity as a flat amount.
+          Add a vest start and length to project stock across years.
         </p>
         {error && <p role="alert" className="text-sm text-destructive">{error}</p>}
         <Button type="submit" disabled={saving} className="min-h-[44px]">

--- a/components/careerotter/comp-tracker.tsx
+++ b/components/careerotter/comp-tracker.tsx
@@ -33,22 +33,40 @@ interface CompEntry {
   shares: number | null;
   vest_start: string | null;
   vest_years: number | null;
+  vest_cliff_months: number | null;
 }
 
 /**
- * Fraction of calendar year `year` that falls inside the vesting window
- * [start, start + vestYears). 1 for fully-vesting years, prorated at the
- * edges, 0 outside the window.
+ * Fraction of the TOTAL grant received during calendar year `year`, for a
+ * grant vesting linearly over vestYears with an optional cliff. Nothing is
+ * received before the cliff; at the cliff the accrued amount vests at once
+ * (e.g. a 12-month cliff on a 4-year grant pays 25% that day), then vesting
+ * continues linearly. Computed as vested(year end) - vested(year start), so
+ * the cliff year correctly gets the lump plus its remaining months.
  */
-export function vestedFractionOfYear(year: number, start: Date, vestYears: number): number {
-  const windowStart = start.getTime();
-  const windowEnd = new Date(start);
-  windowEnd.setMonth(windowEnd.getMonth() + Math.round(vestYears * 12));
+export function grantFractionReceivedInYear(
+  year: number,
+  start: Date,
+  vestYears: number,
+  cliffMonths: number
+): number {
+  const totalMonths = Math.round(vestYears * 12);
+  if (totalMonths <= 0) return 0;
+  const startMs = start.getTime();
+  const end = new Date(start);
+  end.setMonth(end.getMonth() + totalMonths);
+  const cliff = new Date(start);
+  cliff.setMonth(cliff.getMonth() + Math.max(0, cliffMonths));
+
+  const vestedAt = (t: number): number => {
+    if (t < cliff.getTime() || t <= startMs) return 0;
+    if (t >= end.getTime()) return 1;
+    return (t - startMs) / (end.getTime() - startMs);
+  };
+
   const yearStart = new Date(year, 0, 1).getTime();
   const yearEnd = new Date(year + 1, 0, 1).getTime();
-  const overlap =
-    Math.min(yearEnd, windowEnd.getTime()) - Math.max(yearStart, windowStart);
-  return Math.max(0, Math.min(1, overlap / (yearEnd - yearStart)));
+  return Math.max(0, vestedAt(yearEnd) - vestedAt(yearStart));
 }
 
 const usd = (n: number) =>
@@ -93,6 +111,7 @@ export function CompTracker() {
     shares: "",
     vest_start: "",
     vest_years: "",
+    vest_cliff_months: "",
   });
   const [error, setError] = useState("");
   const [saving, setSaving] = useState(false);
@@ -167,6 +186,8 @@ export function CompTracker() {
           // "" means not provided; a typed 0 must reach the API so its
           // validation error surfaces instead of silently storing no vesting.
           vest_years: form.vest_years === "" ? null : Number(form.vest_years),
+          vest_cliff_months:
+            form.vest_cliff_months === "" ? null : Number(form.vest_cliff_months),
         }),
       });
       if (res.ok) {
@@ -179,6 +200,7 @@ export function CompTracker() {
           shares: "",
           vest_start: "",
           vest_years: "",
+          vest_cliff_months: "",
         });
         await load();
       } else {
@@ -246,25 +268,20 @@ export function CompTracker() {
   const nowYear = new Date().getFullYear();
   const projectionYears = [nowYear, nowYear + 1, nowYear + 2];
   const vestYears = latest?.vest_years ? Number(latest.vest_years) : null;
+  const cliffMonths = latest?.vest_cliff_months ? Number(latest.vest_cliff_months) : 0;
   const vestStartDate = latest
     ? new Date(`${latest.vest_start ?? latest.effective_date}T00:00:00`)
     : null;
   const stockForYear = (year: number): number => {
     if (!latest) return 0;
-    if (hasShares) {
-      const grantValue = latestShares * price;
-      if (vestYears && vestStartDate) {
-        return (grantValue / vestYears) * vestedFractionOfYear(year, vestStartDate, vestYears);
-      }
-      return grantValue;
-    }
+    // With a vest schedule, both share-based and flat equity are treated as
+    // the TOTAL grant, and each year receives its vested slice (cliff-aware).
+    const grantValue = hasShares ? latestShares * price : latestEquity;
     if (vestYears && vestStartDate) {
-      // Flat equity with a vest length is a total grant: annualize it the
-      // same way as share-based grants so the projection can never allocate
-      // more than the grant's value across the window.
-      return (latestEquity / vestYears) * vestedFractionOfYear(year, vestStartDate, vestYears);
+      return grantValue * grantFractionReceivedInYear(year, vestStartDate, vestYears, cliffMonths);
     }
-    return latestEquity;
+    // No vest schedule: keep the flat single-year semantics.
+    return grantValue;
   };
   const projection = latest
     ? projectionYears.map((year) => {
@@ -453,8 +470,8 @@ export function CompTracker() {
               <h3 className="text-sm font-semibold text-foreground">Projected comp</h3>
               <p className="text-xs text-muted-foreground">
                 {vestYears
-                  ? `Stock prorated over a ${vestYears}-year vest${hasShares ? " at the scenario price above" : ""}.`
-                  : "Add a vest length to an entry to prorate stock across years."}
+                  ? `Stock over a ${vestYears}-year vest${cliffMonths ? ` with a ${cliffMonths}-month cliff` : ""}${hasShares ? ", valued at the scenario price above" : ""}.`
+                  : "Add a vest length to an entry to spread stock across years."}
               </p>
             </div>
             <div className="overflow-x-auto">
@@ -597,10 +614,17 @@ export function CompTracker() {
               placeholder="e.g. 4"
               className="min-h-[44px]" />
           </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="vest-cliff">Cliff months (optional)</Label>
+            <Input id="vest-cliff" type="number" min="0" max="60" step="1" value={form.vest_cliff_months}
+              onChange={(e) => setForm({ ...form, vest_cliff_months: e.target.value })}
+              placeholder="e.g. 12"
+              className="min-h-[44px]" />
+          </div>
         </div>
         <p className="text-xs text-muted-foreground">
           Enter a ticker and share count to model equity by stock price, or leave Equity as a flat amount.
-          Add a vest start and length to project stock across years.
+          Add a vest start, length, and cliff to project stock across years the way your grant actually pays out.
         </p>
         {error && <p role="alert" className="text-sm text-destructive">{error}</p>}
         <Button type="submit" disabled={saving} className="min-h-[44px]">

--- a/components/careerotter/tailored-resume.tsx
+++ b/components/careerotter/tailored-resume.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+/**
+ * Per-application tailored resume draft. Generates a rewrite of the user's
+ * uploaded resume targeted at this application's saved job description, and
+ * shows the latest saved draft on load.
+ */
+export function TailoredResume({ applicationId }: { applicationId: string }) {
+  const [draft, setDraft] = useState("");
+  const [createdAt, setCreatedAt] = useState<string | null>(null);
+  const [generating, setGenerating] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(
+          `/api/careerotter/tailored-resume?applicationId=${encodeURIComponent(applicationId)}`
+        );
+        const data = await res.json().catch(() => null);
+        if (!cancelled && res.ok && data?.tailoredText) {
+          setDraft(data.tailoredText);
+          setCreatedAt(data.createdAt ?? null);
+        }
+      } catch {
+        // No saved draft — the generate button is the entry point.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [applicationId]);
+
+  async function generate() {
+    setGenerating(true);
+    setError("");
+    setCopied(false);
+    try {
+      const res = await fetch("/api/careerotter/tailored-resume", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ applicationId }),
+      });
+      const data = await res.json().catch(() => null);
+      if (res.ok && data?.tailoredText) {
+        setDraft(data.tailoredText);
+        setCreatedAt(new Date().toISOString());
+      } else {
+        setError(data?.error || "Could not generate a draft right now.");
+      }
+    } catch {
+      setError("Could not generate a draft right now.");
+    } finally {
+      setGenerating(false);
+    }
+  }
+
+  async function copyDraft() {
+    try {
+      await navigator.clipboard.writeText(draft);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setError("Could not copy to clipboard.");
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Tailored Resume</CardTitle>
+        <CardDescription>
+          Rewrite your uploaded resume to target this job description. Uses only
+          what your resume already says, reordered and reworded for this role.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <Button onClick={generate} disabled={generating} className="min-h-[44px]">
+            {generating ? "Generating…" : draft ? "Regenerate draft" : "Generate draft"}
+          </Button>
+          {draft && (
+            <Button
+              variant="outline"
+              onClick={copyDraft}
+              disabled={generating}
+              className="min-h-[44px]"
+            >
+              {copied ? "Copied" : "Copy draft"}
+            </Button>
+          )}
+          {createdAt && (
+            <span className="text-xs text-muted-foreground">
+              Draft from{" "}
+              {new Date(createdAt).toLocaleDateString("en-US", {
+                year: "numeric",
+                month: "short",
+                day: "numeric",
+              })}
+            </span>
+          )}
+        </div>
+        {error && (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+        {draft && (
+          <pre className="max-h-96 overflow-y-auto rounded-md border bg-muted p-4 text-sm whitespace-pre-wrap font-sans">
+            {draft}
+          </pre>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/careerotter/tailored-resume.tsx
+++ b/components/careerotter/tailored-resume.tsx
@@ -50,7 +50,14 @@ export function TailoredResume({ applicationId }: { applicationId: string }) {
       const data = await res.json().catch(() => null);
       if (res.ok && data?.tailoredText) {
         setDraft(data.tailoredText);
-        setCreatedAt(new Date().toISOString());
+        if (data.persisted) {
+          setCreatedAt(new Date().toISOString());
+        } else {
+          // Generated but not saved — show it so the user can copy it out,
+          // with no saved-draft date and a clear warning.
+          setCreatedAt(null);
+          setError("Draft generated but could not be saved. Copy it now — it will not be here after a reload.");
+        }
       } else {
         setError(data?.error || "Could not generate a draft right now.");
       }

--- a/lib/careerotter/coach-prompt.ts
+++ b/lib/careerotter/coach-prompt.ts
@@ -18,6 +18,102 @@ export const COACH_STARTERS = [
   "Am I ready to ask?",
 ] as const;
 
+/**
+ * Guided coaching goals. Each goal is a focused activity: the kickoff is sent
+ * as the user's opening message, and the guidance is appended to the system
+ * prompt so the coach runs a structured flow instead of a one-off answer.
+ * Every flow stays grounded in logged wins — that grounding is the product's
+ * differentiator, so guidance must reference the user's actual evidence.
+ */
+export interface CoachGoal {
+  id: string;
+  stage: string;
+  label: string;
+  description: string;
+  kickoff: string;
+  guidance: string;
+}
+
+export const COACH_GOALS: readonly CoachGoal[] = [
+  {
+    id: "find-gaps",
+    stage: "Build your case",
+    label: "Find my gaps",
+    description: "Audit your case coverage and name what evidence is missing",
+    kickoff: "Audit my case. Where are the gaps?",
+    guidance:
+      "Run a case audit: assess their evidence per impact area, name the weakest areas with counts, and end with the two most valuable wins they could log this week to close the biggest gap.",
+  },
+  {
+    id: "review-bullets",
+    stage: "Build your case",
+    label: "Turn wins into review bullets",
+    description: "Rewrite your logged wins as self-review achievement bullets",
+    kickoff: "Turn my logged wins into self-review bullets.",
+    guidance:
+      "Rewrite their logged wins as tight accomplishment bullets (impact first, numbers where logged, no invented metrics). Group by impact area. Flag any win too vague to use and say what detail would fix it.",
+  },
+  {
+    id: "one-on-one",
+    stage: "Say it out loud",
+    label: "Draft 1:1 talking points",
+    description: "Prepare this week's manager 1:1 around your recent wins",
+    kickoff: "Draft my 1:1 talking points for this week",
+    guidance:
+      "Draft three to five 1:1 talking points from their most recent wins, each one sentence plus a suggested ask or visibility move. Keep it scannable.",
+  },
+  {
+    id: "review-conversation",
+    stage: "Say it out loud",
+    label: "Prep my review conversation",
+    description: "Rehearse the review discussion and likely manager pushback",
+    kickoff: "Help me prep for my review conversation.",
+    guidance:
+      "Run a review rehearsal: propose an opening statement built from their strongest evidence, then raise the two most likely manager pushbacks given their gaps, and coach a grounded response to each. Offer to role-play one exchange at a time.",
+  },
+  {
+    id: "plan-ask",
+    stage: "Get paid",
+    label: "Plan the comp ask",
+    description: "Decide the number, the timing, and the script",
+    kickoff: "Help me plan my comp ask.",
+    guidance:
+      "Build the ask plan: readiness check against their evidence and review date, then timing, then a short script that cites their strongest logged wins. If they have not logged comp or a target, say what to add and where.",
+  },
+  {
+    id: "practice-negotiation",
+    stage: "Get paid",
+    label: "Practice the negotiation",
+    description: "Role-play objections to your ask and sharpen responses",
+    kickoff: "Role-play my comp negotiation. Push back on me.",
+    guidance:
+      "Role-play the negotiation: play the manager, raise one realistic objection at a time (budget, timing, level), and after each user response give one line of feedback grounded in their evidence before the next objection. Stay in the exercise until they ask to stop, then summarize what to tighten.",
+  },
+  {
+    id: "storybank",
+    stage: "Interviews",
+    label: "Build my storybank",
+    description: "Turn logged wins into structured interview stories",
+    kickoff: "Turn my wins into interview stories.",
+    guidance:
+      "Convert their strongest wins into situation-action-result interview stories, two to four sentences each, and name the behavioral question each story best answers. Flag wins missing the detail a story needs.",
+  },
+  {
+    id: "interview-prep",
+    stage: "Interviews",
+    label: "Prep for an interview",
+    description: "Practice likely questions using your own evidence",
+    kickoff: "Help me prep for an upcoming interview.",
+    guidance:
+      "Ask which role and round first if not stated. Then run focused prep: likely questions for that round, which of their logged wins answers each, and one practice question at a time with feedback grounded in their evidence.",
+  },
+] as const;
+
+export function getCoachGoal(id: unknown): CoachGoal | null {
+  if (typeof id !== "string") return null;
+  return COACH_GOALS.find((g) => g.id === id) ?? null;
+}
+
 export interface CoachProfile {
   mode?: string | null;
   role?: string | null;
@@ -43,7 +139,8 @@ const TAG_LABEL: Record<WinTag, string> = Object.fromEntries(
  */
 export function buildCoachSystemPrompt(
   profile: CoachProfile | null,
-  wins: CoachWin[]
+  wins: CoachWin[],
+  activity?: CoachGoal | null
 ): string {
   const goal =
     profile?.mode === "job_search"
@@ -83,6 +180,10 @@ export function buildCoachSystemPrompt(
           })
           .join("\n");
 
+  const goalBlock = activity
+    ? `\n\nThe user chose the guided activity "${activity.label}". ${activity.guidance}`
+    : "";
+
   return `${VOICE_GUARDRAILS}
 
 You are coaching this user toward their goal. You may only reason from the evidence below plus general, well-established negotiation and promotion knowledge. Do not invent wins, numbers, or facts about them. If a good answer needs information they haven't logged, say exactly what's missing and how to log it (one line in the capture bar), then answer with what you do have.
@@ -93,5 +194,5 @@ Their context:
 ${context.join("\n")}
 
 Their logged wins (the only evidence you may cite):
-${winLines}`;
+${winLines}${goalBlock}`;
 }

--- a/lib/careerotter/coach-prompt.ts
+++ b/lib/careerotter/coach-prompt.ts
@@ -109,6 +109,7 @@ export const COACH_GOALS: readonly CoachGoal[] = [
   },
 ] as const;
 
+/** Look up a guided coaching goal by id; null for unknown or non-string input. */
 export function getCoachGoal(id: unknown): CoachGoal | null {
   if (typeof id !== "string") return null;
   return COACH_GOALS.find((g) => g.id === id) ?? null;

--- a/schemas/migrations/038_coach_memory.sql
+++ b/schemas/migrations/038_coach_memory.sql
@@ -4,6 +4,9 @@ CREATE TABLE IF NOT EXISTS public.coach_memory (
   user_id uuid NOT NULL,
   summary text,
   messages jsonb NOT NULL DEFAULT '[]'::jsonb,
+  -- Active guided-activity id (see COACH_GOALS), so a restored session
+  -- continues the flow the user was in rather than the generic prompt.
+  goal_id text,
   updated_at timestamp with time zone DEFAULT now(),
 
   CONSTRAINT coach_memory_pkey PRIMARY KEY (user_id),

--- a/schemas/migrations/038_coach_memory.sql
+++ b/schemas/migrations/038_coach_memory.sql
@@ -1,0 +1,30 @@
+-- Coach memory: one row per user holding the running transcript and a short
+-- model-written summary so the coach can pick up where the user left off.
+CREATE TABLE IF NOT EXISTS public.coach_memory (
+  user_id uuid NOT NULL,
+  summary text,
+  messages jsonb NOT NULL DEFAULT '[]'::jsonb,
+  updated_at timestamp with time zone DEFAULT now(),
+
+  CONSTRAINT coach_memory_pkey PRIMARY KEY (user_id),
+  CONSTRAINT coach_memory_user_id_fkey FOREIGN KEY (user_id)
+    REFERENCES auth.users (id) ON DELETE CASCADE
+);
+
+ALTER TABLE public.coach_memory ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their own coach memory"
+  ON public.coach_memory FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert their own coach memory"
+  ON public.coach_memory FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update their own coach memory"
+  ON public.coach_memory FOR UPDATE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete their own coach memory"
+  ON public.coach_memory FOR DELETE
+  USING (auth.uid() = user_id);

--- a/schemas/migrations/039_tailored_resumes.sql
+++ b/schemas/migrations/039_tailored_resumes.sql
@@ -1,0 +1,18 @@
+-- Per-application AI-tailored resume drafts. Generated from the user's primary
+-- resume text plus the application's saved job description. One draft kept per
+-- application (regenerating overwrites), so the table stays small and the
+-- latest draft is always the one that matches the current JD.
+create table if not exists public.tailored_resumes (
+  id uuid primary key default gen_random_uuid (),
+  user_id uuid not null references public.profiles (id) on delete cascade,
+  application_id uuid not null references public.applications (id) on delete cascade,
+  tailored_text text not null,
+  created_at timestamptz not null default now(),
+  constraint tailored_resumes_application_unique unique (user_id, application_id)
+);
+
+create index if not exists tailored_resumes_user_idx
+  on public.tailored_resumes (user_id, created_at desc);
+
+alter table public.tailored_resumes enable row level security;
+-- No policies: service-role (API routes) only, like comp_entries.

--- a/schemas/migrations/040_comp_vesting.sql
+++ b/schemas/migrations/040_comp_vesting.sql
@@ -1,0 +1,7 @@
+-- Optional vesting schedule on comp entries, so the comp page can project
+-- multi-year total comp instead of only showing a point-in-time number.
+-- vest_start defaults to the entry's effective_date in app logic when absent;
+-- vest_years is the grant's total vesting duration. Both nullable — entries
+-- without them keep the existing flat-equity behavior.
+alter table public.comp_entries add column if not exists vest_start date;
+alter table public.comp_entries add column if not exists vest_years numeric(4,2);

--- a/schemas/migrations/041_comp_vest_cliff.sql
+++ b/schemas/migrations/041_comp_vest_cliff.sql
@@ -1,0 +1,4 @@
+-- Optional vesting cliff on comp entries. With a cliff, nothing vests until
+-- cliff_months after vest_start; the accrued amount then vests at once and
+-- the remainder continues linearly. Null means no cliff (pure linear vest).
+alter table public.comp_entries add column if not exists vest_cliff_months integer;


### PR DESCRIPTION
## Summary

Closes the four buildable gaps from the 2026-08-07 TrueUp competitive audit. On every feature surface both products share, CareerOtter now matches or beats TrueUp — with logged-wins grounding as the differentiator TrueUp cannot copy.

- **Coach memory** (`038_coach_memory.sql`): each exchange persists the transcript plus a model-written two-sentence summary; the chat restores prior sessions with a "pick up where you left off" card and a start-fresh action. Persistence runs in `after()` so replies are never blocked.
- **Guided coach flows**: 8 activities across Build your case / Say it out loud / Get paid / Interviews. Each sends a kickoff message and pins structured guidance into the system prompt for the whole conversation; all flows must cite the user's actual logged wins.
- **Tailored resume drafts** (`039_tailored_resumes.sql`): Pro-gated, per-application rewrite of the uploaded resume against the saved job description (strict no-invented-facts prompt). One draft per application, upserted on regenerate. New card on the application detail page.
- **Comp vesting projections** (`040_comp_vesting.sql`): optional `vest_start`/`vest_years` on comp entries; 3-year Salary/Incentives/Stock/Total projection prorated across the vest window and driven by the existing live-price scenario slider, plus an estimated take-home row with a user-set effective tax rate.

## Migrations (run in order)

```
./scripts/run-schema.sh schemas/migrations/038_coach_memory.sql
./scripts/run-schema.sh schemas/migrations/039_tailored_resumes.sql
./scripts/run-schema.sh schemas/migrations/040_comp_vesting.sql
```

## Testing

- 11 new tests in `__tests__/lib/careerotter-coach-goals.test.ts` (goal registry integrity, `getCoachGoal`, prompt builder with/without an activity, `vestedFractionOfYear` proration) — all passing.
- Pre-existing coach/coverage suites (16 tests) still pass.
- `tsc --noEmit` clean on every touched file (repo baseline errors untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added guided coaching activities with goal-specific prompts, saved sessions, summaries, and session clearing.
  - Added Pro tailored resume generation, regeneration, copying, and saved drafts within applications.
  - Added vesting schedules, cliff support, and three-year compensation projections with estimated take-home pay.
  - Updated application branding and messaging.

- **Bug Fixes**
  - Improved validation for impossible compensation dates and vesting values.

- **Tests**
  - Added coverage for coaching, tailored resumes, compensation vesting, and session restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->